### PR TITLE
New default renderer with 2-6x better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,16 +151,16 @@ user_table = html.table(
 
 ### Rendering
 
-`htmy.HTMY` is the built-in, default renderer of the library.
+`htmy.Renderer` is the built-in, default renderer of the library.
 
-If you're using the library in an async web framework like [FastAPI](https://fastapi.tiangolo.com/), then you're already in an async environment, so you can render components as simply as this: `await HTMY().render(my_root_component)`.
+If you're using the library in an async web framework like [FastAPI](https://fastapi.tiangolo.com/), then you're already in an async environment, so you can render components as simply as this: `await Renderer().render(my_root_component)`.
 
 If you're trying to run the renderer in a sync environment, like a local script or CLI, then you first need to wrap the renderer in an async task and execute that task with `asyncio.run()`:
 
 ```python
 import asyncio
 
-from htmy import HTMY, html
+from htmy import Renderer, html
 
 async def render_page() -> None:
     page = (
@@ -173,7 +173,7 @@ async def render_page() -> None:
         )
     )
 
-    result = await HTMY().render(page)
+    result = await Renderer().render(page)
     print(result)
 
 
@@ -194,7 +194,7 @@ Here's an example context provider and consumer implementation:
 ```python
 import asyncio
 
-from htmy import HTMY, Component, ComponentType, Context, component, html
+from htmy import Component, ComponentType, Context, Renderer, component, html
 
 class UserContext:
     def __init__(self, *children: ComponentType, username: str, theme: str) -> None:
@@ -240,7 +240,7 @@ async def render_welcome_page() -> None:
         theme="dark",
     )
 
-    result = await HTMY().render(page)
+    result = await Renderer().render(page)
     print(result)
 
 if __name__ == "__main__":
@@ -251,7 +251,7 @@ You can of course rely on the built-in context related utilities like the `Conte
 
 ### Formatter
 
-As mentioned before, the built-in `Formatter` class is responsible for tag attribute name and value formatting. You can completely override or extend the built-in formatting behavior simply by extending this class or adding new rules to an instance of it, and then adding the custom instance to the context, either directly in `HTMY` or `HTMY.render()`, or in a context provider component.
+As mentioned before, the built-in `Formatter` class is responsible for tag attribute name and value formatting. You can completely override or extend the built-in formatting behavior simply by extending this class or adding new rules to an instance of it, and then adding the custom instance to the context, either directly in `Renderer` or `Renderer.render()`, or in a context provider component.
 
 These are default tag attribute formatting rules:
 

--- a/docs/api/renderer/baseline.md
+++ b/docs/api/renderer/baseline.md
@@ -1,4 +1,4 @@
-# ::: htmy.renderer.recursive
+# ::: htmy.renderer.baseline
 
     options:
         show_root_heading: true

--- a/docs/api/renderer/default.md
+++ b/docs/api/renderer/default.md
@@ -1,0 +1,4 @@
+# ::: htmy.renderer.default
+
+    options:
+        show_root_heading: true

--- a/docs/api/renderer/recursive.md
+++ b/docs/api/renderer/recursive.md
@@ -1,4 +1,4 @@
-# ::: htmy.renderer
+# ::: htmy.renderer.recursive
 
     options:
         show_root_heading: true

--- a/docs/examples/fastapi-htmx-tailwind-daisyui.md
+++ b/docs/examples/fastapi-htmx-tailwind-daisyui.md
@@ -18,7 +18,7 @@ from typing import Annotated
 from fastapi import Depends, FastAPI, Request
 from fastapi.responses import HTMLResponse
 
-from htmy import HTMY, Component, ComponentType, Context, component, html, is_component_sequence
+from htmy import Component, ComponentType, Context, Renderer, component, html, is_component_sequence
 
 
 @dataclass
@@ -30,7 +30,7 @@ class User:
 
 
 def make_htmy_context(request: Request) -> Context:
-    """Creates the base HTMY context for rendering."""
+    """Creates the base htmy context for rendering."""
     # The context will map the `Request` type to the current request and the User class
     # to the current user. This is similar to what the `ContextAware` utility does, but
     # simpler. With this context, components will be able to easily access the request
@@ -42,14 +42,14 @@ RendererFunction = Callable[[Component], Awaitable[HTMLResponse]]
 
 
 def render(request: Request) -> RendererFunction:
-    """FastAPI dependency that returns an HTMY renderer function."""
+    """FastAPI dependency that returns an htmy renderer function."""
 
     async def exec(component: Component) -> HTMLResponse:
-        # Note that we add the result of `make_htmy_context()` as the default context to the
-        # `HTMY` renderer. This way wherever this function is used for rendering in routes,
+        # Note that we add the result of `make_htmy_context()` as the default context to
+        # the renderer. This way wherever this function is used for rendering in routes,
         # every rendered component will be able to access the current request and user.
-        htmy = HTMY(make_htmy_context(request))
-        return HTMLResponse(await htmy.render(component))
+        renderer = Renderer(make_htmy_context(request))
+        return HTMLResponse(await renderer.render(component))
 
     return exec
 

--- a/docs/examples/internationalization.md
+++ b/docs/examples/internationalization.md
@@ -4,7 +4,7 @@ The focus of this example is using the built-in `I18n` utility for international
 
 First of all, we must create some translation resources (plain JSON files). Let's do this by creating the `locale/en/page` folder structure and adding a `hello.json` in the `page` folder with the following content: `{ "message": "Hey {name}" }`. Notice the Python format string in the value for the `"message"` key, such strings can be automatically formatted by `I18n`, see the details in the docs and in the usage example below.
 
-Using `I18n` consists of only two steps: create an `I18n` instance, and include it in the `HTMY` rendering context so it can be accessed by components in their `htmy()` (render) method.
+Using `I18n` consists of only two steps: create an `I18n` instance, and include it in the rendering context so it can be accessed by components in their `htmy()` (render) method.
 
 With the translation resource in place, we can create the `app.py` file and implement our translated components like this:
 
@@ -12,12 +12,12 @@ With the translation resource in place, we can create the `app.py` file and impl
 import asyncio
 from pathlib import Path
 
-from htmy import HTMY, Component, Context, html
+from htmy import Component, Context, Renderer, html
 from htmy.i18n import I18n
 
 
 class TranslatedComponent:
-    """HTMY component with translated content."""
+    """Component with translated content."""
 
     async def htmy(self, context: Context) -> Component:
         # Get the I18n instance from the rendering context.
@@ -39,14 +39,14 @@ base_folder = Path(__file__).parent
 
 i18n = I18n(base_folder / "locale" / "en")
 """
-The `I18n` instance that we can add to the `HTMY` rendering context.
+The `I18n` instance that we can add to the rendering context.
 
 It takes translations from the `locale/en` folder.
 """
 
 
 async def render_hello() -> None:
-    rendered = await HTMY().render(
+    rendered = await Renderer().render(
         # Render a TranslatedComponent.
         TranslatedComponent(),
         # Include the created I18n instance in the rendering context.

--- a/docs/examples/markdown.md
+++ b/docs/examples/markdown.md
@@ -41,12 +41,12 @@ Then we can create the most minimal version of `app.py` that will be responsible
 ```python
 import asyncio
 
-from htmy import HTMY, md
+from htmy import Renderer, md
 
 
 async def render_post() -> None:
     md_post = md.MD("post.md")  # Create an htmy.md.MD component.
-    rendered = await HTMY().render(md_post)  # Render the MD component.
+    rendered = await Renderer().render(md_post)  # Render the MD component.
     print(rendered)  # Print the result.
 
 
@@ -65,7 +65,7 @@ The `post.md` file can remain the same as above, but `app.py` will change quite 
 First of all we need a few more import (although some only for typing):
 
 ```python
-from htmy import HTMY, Component, ComponentType, Context, PropertyValue, etree, html, md
+from htmy import Component, ComponentType, Context, PropertyValue, Renderer, etree, html, md
 ```
 
 Next we need a `Page` component that defines the base HTML structure of the webpage:
@@ -156,7 +156,7 @@ async def render_post() -> None:
         converter=md_converter.convert,  # And make it use our element converter's conversion method.
     )
     page = Page(md_post)  # Wrap the post in a Page component.
-    rendered = await HTMY().render(page)  # Render the MD component.
+    rendered = await Renderer().render(page)  # Render the MD component.
     print(rendered)  # Print the result.
 ```
 
@@ -202,7 +202,7 @@ Then we can create the `PostInfo` `htmy` component:
 
 ```python
 class PostInfo:
-    """HTMY component for post info rendering."""
+    """Component for post info rendering."""
 
     def __init__(self, author: str, published_at: str) -> None:
         self.author = author

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,16 +151,16 @@ user_table = html.table(
 
 ### Rendering
 
-`htmy.HTMY` is the built-in, default renderer of the library.
+`htmy.Renderer` is the built-in, default renderer of the library.
 
-If you're using the library in an async web framework like [FastAPI](https://fastapi.tiangolo.com/), then you're already in an async environment, so you can render components as simply as this: `await HTMY().render(my_root_component)`.
+If you're using the library in an async web framework like [FastAPI](https://fastapi.tiangolo.com/), then you're already in an async environment, so you can render components as simply as this: `await Renderer().render(my_root_component)`.
 
 If you're trying to run the renderer in a sync environment, like a local script or CLI, then you first need to wrap the renderer in an async task and execute that task with `asyncio.run()`:
 
 ```python
 import asyncio
 
-from htmy import HTMY, html
+from htmy import Renderer, html
 
 async def render_page() -> None:
     page = (
@@ -173,7 +173,7 @@ async def render_page() -> None:
         )
     )
 
-    result = await HTMY().render(page)
+    result = await Renderer().render(page)
     print(result)
 
 
@@ -194,7 +194,7 @@ Here's an example context provider and consumer implementation:
 ```python
 import asyncio
 
-from htmy import HTMY, Component, ComponentType, Context, component, html
+from htmy import Component, ComponentType, Context, Renderer, component, html
 
 class UserContext:
     def __init__(self, *children: ComponentType, username: str, theme: str) -> None:
@@ -240,7 +240,7 @@ async def render_welcome_page() -> None:
         theme="dark",
     )
 
-    result = await HTMY().render(page)
+    result = await Renderer().render(page)
     print(result)
 
 if __name__ == "__main__":
@@ -251,7 +251,7 @@ You can of course rely on the built-in context related utilities like the `Conte
 
 ### Formatter
 
-As mentioned before, the built-in `Formatter` class is responsible for tag attribute name and value formatting. You can completely override or extend the built-in formatting behavior simply by extending this class or adding new rules to an instance of it, and then adding the custom instance to the context, either directly in `HTMY` or `HTMY.render()`, or in a context provider component.
+As mentioned before, the built-in `Formatter` class is responsible for tag attribute name and value formatting. You can completely override or extend the built-in formatting behavior simply by extending this class or adding new rules to an instance of it, and then adding the custom instance to the context, either directly in `Renderer` or `Renderer.render()`, or in a context provider component.
 
 These are default tag attribute formatting rules:
 

--- a/examples/internationalization/app.py
+++ b/examples/internationalization/app.py
@@ -1,12 +1,12 @@
 import asyncio
 from pathlib import Path
 
-from htmy import HTMY, Component, Context, html
+from htmy import Component, Context, Renderer, html
 from htmy.i18n import I18n
 
 
 class TranslatedComponent:
-    """HTMY component with translated content."""
+    """Component with translated content."""
 
     async def htmy(self, context: Context) -> Component:
         # Get the I18n instance from the rendering context.
@@ -25,14 +25,14 @@ base_folder = Path(__file__).parent
 
 i18n = I18n(base_folder / "locale" / "en")
 """
-The `I18n` instance that we can add to the `HTMY` rendering context.
+The `I18n` instance that we can add to the rendering context.
 
 It takes translations from the `locale/en` folder.
 """
 
 
 async def render_hello() -> None:
-    rendered = await HTMY().render(
+    rendered = await Renderer().render(
         # Render a TranslatedComponent.
         TranslatedComponent(),
         # Include the created I18n instance in the rendering context.

--- a/examples/markdown_customization/app.py
+++ b/examples/markdown_customization/app.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from htmy import HTMY, Component, ComponentType, Context, PropertyValue, etree, html, md
+from htmy import Component, ComponentType, Context, PropertyValue, Renderer, etree, html, md
 
 
 class Page:
@@ -34,7 +34,7 @@ class Page:
 
 
 class PostInfo:
-    """HTMY component for post info rendering."""
+    """Component for post info rendering."""
 
     def __init__(self, author: str, published_at: str) -> None:
         self.author = author
@@ -91,7 +91,7 @@ async def render_post() -> None:
         converter=md_converter.convert,  # And make it use our element converter's conversion method.
     )
     page = Page(md_post)  # Wrap the post in a Page component.
-    rendered = await HTMY().render(page)  # Render the MD component.
+    rendered = await Renderer().render(page)  # Render the MD component.
     print(rendered)  # Print the result.
 
 

--- a/examples/markdown_essentials/app.py
+++ b/examples/markdown_essentials/app.py
@@ -1,11 +1,11 @@
 import asyncio
 
-from htmy import HTMY, md
+from htmy import Renderer, md
 
 
 async def render_post() -> None:
     md_post = md.MD("post.md")  # Create an htmy.md.MD component.
-    rendered = await HTMY().render(md_post)  # Render the MD component.
+    rendered = await Renderer().render(md_post)  # Render the MD component.
     print(rendered)  # Print the result.
 
 

--- a/htmy/__init__.py
+++ b/htmy/__init__.py
@@ -15,7 +15,7 @@ from .core import WithContext as WithContext
 from .core import XBool as XBool
 from .core import component as component
 from .core import xml_format_string as xml_format_string
-from .renderer import HTMY as HTMY
+from .renderer import Renderer as Renderer
 from .typing import AsyncComponent as AsyncComponent
 from .typing import AsyncContextProvider as AsyncContextProvider
 from .typing import AsyncFunctionComponent as AsyncFunctionComponent
@@ -36,3 +36,6 @@ from .typing import SyncContextProvider as SyncContextProvider
 from .typing import SyncFunctionComponent as SyncFunctionComponent
 from .typing import is_component_sequence as is_component_sequence
 from .utils import join_components as join_components
+
+HTMY = Renderer
+"""Deprecated alias for `Renderer`."""

--- a/htmy/core.py
+++ b/htmy/core.py
@@ -122,7 +122,7 @@ class WithContext(Fragment):
         self._context = context
 
     def htmy_context(self) -> Context:
-        """Returns an HTMY context for child rendering."""
+        """Returns the context for child rendering."""
         return self._context
 
 
@@ -174,7 +174,7 @@ class Snippet:
     def _render_text(self, text: str, context: Context) -> Component:
         """
         Render function that takes the text that must be rendered and the current rendering context,
-        and returns the corresponding HTMY component.
+        and returns the corresponding component.
         """
         return SafeStr(text)
 
@@ -523,7 +523,7 @@ class BaseTag(abc.ABC):
 
     @abc.abstractmethod
     def htmy(self, context: Context) -> Component:
-        """Abstract base method for HTMY rendering."""
+        """Abstract base component implementation."""
         ...
 
     def _get_htmy_name(self) -> str:

--- a/htmy/etree.py
+++ b/htmy/etree.py
@@ -17,7 +17,7 @@ from htmy.core import Fragment, SafeStr, WildcardTag
 
 class ETreeConverter:
     """
-    Utility for converting XML strings to custom HTMY components.
+    Utility for converting XML strings to custom components.
     """
 
     __slots__ = ("_rules",)
@@ -33,12 +33,12 @@ class ETreeConverter:
         Initialization.
 
         Arguments:
-            rules: Tag-name to HTMY component conversion rules.
+            rules: Tag-name to component conversion rules.
         """
         self._rules = rules
 
     def convert(self, element: str) -> ComponentType:
-        """Converts the given (possible multi-root) XML string to an HTMY component."""
+        """Converts the given (possibly multi-root) XML string to a component."""
         if len(self._rules) == 0:
             return SafeStr(element)
 
@@ -46,7 +46,7 @@ class ETreeConverter:
         return self.convert_element(ET.fromstring(element))  # noqa: S314 # Only use from XML strings from a trusted source.
 
     def convert_element(self, element: Element) -> ComponentType:
-        """Converts the given `Element` to an HTMY component."""
+        """Converts the given `Element` to a component."""
         rules = self._rules
         if len(rules) == 0:
             return SafeStr(ET.tostring(element))
@@ -67,7 +67,7 @@ class ETreeConverter:
 
     def _convert_properties(self, element: Element) -> Properties:
         """
-        Converts the attributes of the given `Element` to an HTMY `Properties` mapping.
+        Converts the attributes of the given `Element` to a `Properties` mapping.
 
         This method should not alter property names in any way.
         """
@@ -75,8 +75,8 @@ class ETreeConverter:
 
     def _convert_children(self, element: Element) -> Generator[ComponentType, None, None]:
         """
-        Generator that converts all (text and `Element`) children of the given `Element`
-        into an HTMY component."""
+        Generator that converts all (text and `Element`) children of the given `Element` to a component.
+        """
         if text := self._process_text(element.text):
             yield text
 

--- a/htmy/md/core.py
+++ b/htmy/md/core.py
@@ -99,9 +99,9 @@ class MD(Snippet):
         Arguments:
             path_or_text: The path where the markdown file is located or a markdown `Text`.
             converter: Function that converts an HTML string (the parsed and processed markdown text)
-                into an HTMY component.
-            renderer: Function that get the parsed and converted content and the metadata (if it exists)
-                and turns them into an HTMY component.
+                into a component.
+            renderer: Function that gets the parsed and converted content and the metadata (if it exists)
+                and turns them into a component.
             text_processor: An optional text processors that can be used to process the text
                 content before rendering. It can be used for example for token replacement or
                 string formatting.

--- a/htmy/renderer/__init__.py
+++ b/htmy/renderer/__init__.py
@@ -1,8 +1,8 @@
+from .baseline import Renderer as _BaselineRenderer
 from .default import Renderer as _DefaultRenderer
-from .recursive import Renderer as _RecursiveRenderer
 
 Renderer = _DefaultRenderer
 """The default renderer."""
 
-RecursiveRenderer = _RecursiveRenderer
-"""A simple recursive renderer."""
+BaselineRenderer = _BaselineRenderer
+"""The baseline renderer."""

--- a/htmy/renderer/__init__.py
+++ b/htmy/renderer/__init__.py
@@ -1,0 +1,8 @@
+from .default import Renderer as _DefaultRenderer
+from .recursive import Renderer as _RecursiveRenderer
+
+Renderer = _DefaultRenderer
+"""The default renderer."""
+
+RecursiveRenderer = _RecursiveRenderer
+"""A simple recursive renderer."""

--- a/htmy/renderer/baseline.py
+++ b/htmy/renderer/baseline.py
@@ -10,7 +10,7 @@ from htmy.typing import Component, ComponentType, Context
 
 class Renderer:
     """
-    Recursive component renderer.
+    The baseline component renderer.
 
     Because of the simple, recursive implementation, this renderer is the easiest to reason about.
     Therefore it is useful for validating component correctness before bug reporting (if another

--- a/htmy/renderer/default.py
+++ b/htmy/renderer/default.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import asyncio
+from collections import ChainMap, deque
+from collections.abc import Awaitable, Callable, Iterator
+from typing import TypeAlias
+
+from htmy.core import ErrorBoundary, xml_format_string
+from htmy.typing import Component, ComponentType, Context, ContextProvider, is_component_sequence
+
+
+class _Node:
+    """A single node in the linked list the renderer constructs to resolve a component tree."""
+
+    __slots__ = ("component", "next")
+
+    def __init__(self, component: ComponentType, next: _Node | None = None) -> None:
+        """
+        Initialization.
+
+        Arguments:
+            component: The component in this node.
+            next: The next component in the list, if there is one.
+        """
+        self.component = component
+        self.next = next
+
+    def iter_nodes(self, *, include_self: bool = True) -> Iterator[_Node]:
+        """
+        Iterates over all following nodes.
+
+        Arguments:
+            include_self: Whether the node on which this method is called should also
+                be included in the iterator.
+        """
+        current = self if include_self else self.next
+        while current is not None:
+            yield current
+            current = current.next
+
+
+_NodeAndChildContext: TypeAlias = tuple[_Node, Context]
+
+
+class _ComponentRenderer:
+    """
+    `ComponentType` renderer that converts a component tree into a linked list of resolved (`str`) nodes.
+    """
+
+    __slots__ = ("_async_todos", "_error_boundary_todos", "_sync_todos", "_root", "_string_formatter")
+
+    def __init__(
+        self,
+        component: ComponentType,
+        context: Context,
+        *,
+        string_formatter: Callable[[str], str],
+    ) -> None:
+        """
+        Initialization.
+
+        Arguments:
+            component: The component to render.
+            context: The base context to use for rendering the component.
+            string_formatter: The string formatter to use.
+        """
+        self._async_todos: deque[_NodeAndChildContext] = deque()
+        """Async node - context tuples that need to be rendered."""
+        self._error_boundary_todos: deque[_NodeAndChildContext] = deque()
+        """Node context tuples where `node.component` is an `ErrorBoundary`."""
+        self._sync_todos: deque[_NodeAndChildContext] = deque()
+        """
+        Sync node - context tuples that need to be rendered (`node.component` is an `HTMYComponentType`).
+        """
+        self._string_formatter = string_formatter
+        """The string formatter to use."""
+
+        if isinstance(component, str):
+            root = _Node(string_formatter(component), None)
+        else:
+            root = _Node(component, None)
+            self._schedule_node(root, context)
+        self._root = root
+        """The root node in the linked list the renderer constructs."""
+
+    async def _extend_context(self, component: ContextProvider, context: Context) -> Context:
+        """
+        Returns a new context from the given component and context.
+
+        Arguments:
+            component: A `ContextProvider` component.
+            context: The current rendering context.
+        """
+        extra_context: Context | Awaitable[Context] = component.htmy_context()
+        if isinstance(extra_context, Awaitable):
+            extra_context = await extra_context
+
+        return (
+            # Context must not be mutated. We can ignore that ChainMap expects mutable mappings.
+            ChainMap(extra_context, context)  # type: ignore[arg-type]
+            if extra_context
+            else context
+        )
+
+    async def _process_error_boundary(self, node: _Node, context: Context) -> None:
+        """
+        Processes a single node whose component is an `ErrorBoundary`.
+        """
+        component: ErrorBoundary = node.component
+        if hasattr(component, "htmy_context"):  # isinstance() is too expensive.
+            context = await self._extend_context(component, context)
+
+        try:
+            result = await _render_component(
+                component.htmy(context),
+                context=context,
+                string_formatter=self._string_formatter,
+            )
+        except Exception as e:
+            renderer = _ComponentRenderer(
+                component.fallback_component(e),
+                context,
+                string_formatter=self._string_formatter,
+            )
+            result = await renderer.run()
+
+        node.component = result  # No string formatting.
+
+    def _process_node_result(self, parent_node: _Node, component: Component, context: Context) -> None:
+        """
+        Processes the result of a single node.
+
+        Arguments:
+            parent_node: The node that was resolved.
+            component: The (awaited if async) result of `parent_node.component.htmy()`.
+            context: The context that was used for rendering `parent_node.component`.
+        """
+        schedule_node = self._schedule_node
+        string_formatter = self._string_formatter
+        if is_component_sequence(component):
+            if len(component) == 0:
+                parent_node.component = ""
+                return
+
+            first_comp, *rest_comps = component
+            if isinstance(first_comp, str):
+                parent_node.component = string_formatter(first_comp)
+            else:
+                parent_node.component = first_comp
+                schedule_node(parent_node, context)
+
+            old_next = parent_node.next
+            last: _Node = parent_node
+            for c in rest_comps:
+                if isinstance(c, str):
+                    node = _Node(string_formatter(c), old_next)
+                else:
+                    node = _Node(c, old_next)
+                    schedule_node(node, context)
+
+                last.next = node
+                last = node
+        else:
+            if isinstance(component, str):
+                parent_node.component = string_formatter(component)
+            else:
+                parent_node.component = component
+                schedule_node(parent_node, context)
+
+    async def _process_async_node(self, node: _Node, context: Context) -> None:
+        """
+        Processes the given node. `node.component` must be an async component.
+        """
+        result = await node.component.htmy(context)
+        self._process_node_result(node, result, context)
+
+    def _schedule_node(self, node: _Node, child_context: Context) -> None:
+        """
+        Schedules the given node for rendering with the given child context.
+
+        `node.component` must be an `HTMYComponentType` (single component and not `str`).
+        """
+        component = node.component
+        if asyncio.iscoroutinefunction(component.htmy):
+            self._async_todos.append((node, child_context))
+        elif isinstance(component, ErrorBoundary):
+            self._error_boundary_todos.append((node, child_context))
+        else:
+            self._sync_todos.append((node, child_context))
+
+    async def run(self) -> str:
+        """Runs the component renderer."""
+        async_todos = self._async_todos
+        sync_todos = self._sync_todos
+        process_node_result = self._process_node_result
+        process_async_node = self._process_async_node
+
+        while sync_todos or async_todos:
+            while sync_todos:
+                node, child_context = sync_todos.pop()
+                component = node.component
+                if hasattr(component, "htmy_context"):  # isinstance() is too expensive.
+                    child_context = await self._extend_context(component, child_context)
+
+                if asyncio.iscoroutinefunction(node.component.htmy):
+                    async_todos.append(node, child_context)
+                else:
+                    result = node.component.htmy(child_context)
+                    process_node_result(node, result, child_context)
+
+            if async_todos:
+                await asyncio.gather(*(process_async_node(n, ctx) for n, ctx in async_todos))
+                async_todos.clear()
+
+        if self._error_boundary_todos:
+            await asyncio.gather(
+                *(self._process_error_boundary(n, ctx) for n, ctx in self._error_boundary_todos)
+            )
+
+        return "".join(node.component for node in self._root.iter_nodes())
+
+
+async def _render_component(
+    component: Component,
+    *,
+    context: Context,
+    string_formatter: Callable[[str], str],
+) -> str:
+    """Renders the given component with the given settings."""
+    if is_component_sequence(component):
+        if len(component) == 0:
+            return ""
+
+        renderers = (_ComponentRenderer(c, context, string_formatter=string_formatter) for c in component)
+        return "".join(await asyncio.gather(*(r.run() for r in renderers)))
+    else:
+        return await _ComponentRenderer(component, context, string_formatter=string_formatter).run()
+
+
+class Renderer:
+    """
+    The default renderer.
+
+    It resolves component trees by converting them to a linked list of resolved component parts
+    before combining them to the final string.
+    """
+
+    __slots__ = ("_default_context", "_string_formatter")
+
+    def __init__(
+        self,
+        default_context: Context | None = None,
+        *,
+        string_formatter: Callable[[str], str] = xml_format_string,
+    ) -> None:
+        """
+        Initialization.
+
+        Arguments:
+            default_context: The default context to use for rendering if `render()` doesn't
+                receive a context.
+            string_formatter: Callable that should be used to format plain strings. By default
+                an XML-safe string formatter will be used.
+        """
+        self._default_context: Context = {} if default_context is None else default_context
+        self._string_formatter = string_formatter
+
+    async def render(self, component: Component, context: Context | None = None) -> str:
+        """
+        Renders the given component.
+
+        Arguments:
+            component: The component to render.
+            context: An optional rendering context.
+
+        Returns:
+            The rendered string.
+        """
+        # Type ignore: ChainMap expects mutable mappings, but context mutation is not allowed so don't care.
+        context: Context = (
+            self._default_context if context is None else ChainMap(context, self._default_context)  # type: ignore[arg-type]
+        )
+        return await _render_component(component, context=context, string_formatter=self._string_formatter)

--- a/htmy/renderer/recursive.py
+++ b/htmy/renderer/recursive.py
@@ -4,12 +4,21 @@ import asyncio
 from collections import ChainMap
 from collections.abc import Awaitable, Callable, Iterable
 
-from .core import ErrorBoundary, xml_format_string
-from .typing import Component, ComponentType, Context
+from htmy.core import ErrorBoundary, xml_format_string
+from htmy.typing import Component, ComponentType, Context
 
 
-class HTMY:
-    """HTMY component renderer."""
+class Renderer:
+    """
+    Recursive component renderer.
+
+    Because of the simple, recursive implementation, this renderer is the easiest to reason about.
+    Therefore it is useful for validating component correctness before bug reporting (if another
+    renderer implementation fails), testing and debugging alternative implementations, and it can
+    also serve as the baseline for benchmarking optimized renderers.
+
+    The performance of this renderer is not production quality.
+    """
 
     __slots__ = ("_default_context", "_string_formatter")
 

--- a/htmy/typing.py
+++ b/htmy/typing.py
@@ -88,7 +88,7 @@ class SyncContextProvider(Protocol):
     """Protocol definition for sync context providers."""
 
     def htmy_context(self) -> Context:
-        """Returns an HTMY context for child rendering."""
+        """Returns a context for child rendering."""
         ...
 
 
@@ -97,7 +97,7 @@ class AsyncContextProvider(Protocol):
     """Protocol definition for async context providers."""
 
     async def htmy_context(self) -> Context:
-        """Returns an HTMY context for child rendering."""
+        """Returns a context for child rendering."""
         ...
 
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -52,7 +52,7 @@ nav:
       - api/core.md
       - Renderer:
           - api/renderer/default.md
-          - api/renderer/recursive.md
+          - api/renderer/baseline.md
       - HTML: api/html.md
       - Markdown: api/md.md
       - I18n: api/i18n.md

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -50,7 +50,9 @@ nav:
       - examples/internationalization.md
   - API Reference:
       - api/core.md
-      - api/renderer.md
+      - Renderer:
+          - api/renderer/default.md
+          - api/renderer/recursive.md
       - HTML: api/html.md
       - Markdown: api/md.md
       - I18n: api/i18n.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "htmy"
-version = "0.3.6"
+version = "0.4.0"
 description = "Async, pure-Python rendering engine."
 authors = ["Peter Volf <do.volfp@gmail.com>"]
 license = "MIT"
@@ -47,13 +47,13 @@ exclude = [
     "docs",
 ]
 lint.select = [
+    "B",  # flake8-bugbear
+    "C",  # flake8-comprehensions
     "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
     "F",  # pyflakes
     "I",  # isort
     "S",  # flake8-bandit - we must ignore these rules in tests
-    "C",  # flake8-comprehensions
-    "B",  # flake8-bugbear
+    "W",  # pycodestyle warnings
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from htmy.renderer import RecursiveRenderer, Renderer
+from htmy.renderer import BaselineRenderer, Renderer
 
 
 @pytest.fixture(scope="session")
@@ -9,5 +9,5 @@ def default_renderer() -> Renderer:
 
 
 @pytest.fixture(scope="session")
-def recursive_renderer() -> RecursiveRenderer:
-    return RecursiveRenderer()
+def baseline_renderer() -> BaselineRenderer:
+    return BaselineRenderer()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from htmy.renderer import RecursiveRenderer, Renderer
+
+
+@pytest.fixture(scope="session")
+def default_renderer() -> Renderer:
+    return Renderer()
+
+
+@pytest.fixture(scope="session")
+def recursive_renderer() -> RecursiveRenderer:
+    return RecursiveRenderer()

--- a/tests/test_main_components.py
+++ b/tests/test_main_components.py
@@ -16,7 +16,7 @@ from htmy import (
     XBool,
     component,
 )
-from htmy.renderer import RecursiveRenderer, Renderer
+from htmy.renderer import BaselineRenderer, Renderer
 
 
 class Page:
@@ -145,7 +145,7 @@ class Page:
 )
 async def test_complex_page_rendering(
     default_renderer: Renderer,
-    recursive_renderer: RecursiveRenderer,
+    baseline_renderer: BaselineRenderer,
     page: Component,
     context: Context | None,
     expected: str,
@@ -153,5 +153,5 @@ async def test_complex_page_rendering(
     result = await default_renderer.render(page, context)
     assert result == expected
 
-    result = await recursive_renderer.render(page, context)
+    result = await baseline_renderer.render(page, context)
     assert result == expected

--- a/tests/test_main_components.py
+++ b/tests/test_main_components.py
@@ -6,7 +6,6 @@ from typing import Any
 import pytest
 
 from htmy import (
-    HTMY,
     Component,
     Context,
     ErrorBoundary,
@@ -17,6 +16,7 @@ from htmy import (
     XBool,
     component,
 )
+from htmy.renderer import RecursiveRenderer, Renderer
 
 
 class Page:
@@ -137,11 +137,21 @@ class Page:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("htmy", "page", "context", "expected"),
-    ((HTMY(), Page.page(), None, Page.rendered()),),
+    ("page", "context", "expected"),
+    (
+        (Page.page(), None, Page.rendered()),
+        (Page.page(), None, Page.rendered()),
+    ),
 )
 async def test_complex_page_rendering(
-    htmy: HTMY, page: Component, context: Context | None, expected: str
+    default_renderer: Renderer,
+    recursive_renderer: RecursiveRenderer,
+    page: Component,
+    context: Context | None,
+    expected: str,
 ) -> None:
-    result = await htmy.render(page, context)
+    result = await default_renderer.render(page, context)
+    assert result == expected
+
+    result = await recursive_renderer.render(page, context)
     assert result == expected

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -15,7 +15,7 @@ from htmy import (
     is_component_sequence,
     md,
 )
-from htmy.renderer import RecursiveRenderer
+from htmy.renderer import BaselineRenderer
 from htmy.typing import TextProcessor
 
 from .utils import tests_root
@@ -160,7 +160,7 @@ async def test_parsing(
     assert isinstance(rendered, str)
     assert rendered == expected
 
-    rendered = await RecursiveRenderer().render(md_component)
+    rendered = await BaselineRenderer().render(md_component)
     assert isinstance(rendered, str)
     assert rendered == expected
 
@@ -222,7 +222,7 @@ async def test_parsing_and_conversion(
     rendered = await Renderer().render(md_component)
     assert rendered == expected
 
-    rendered = await RecursiveRenderer().render(md_component)
+    rendered = await BaselineRenderer().render(md_component)
     assert rendered == expected
 
     md_component_with_renderer = md.MD(
@@ -238,7 +238,7 @@ async def test_parsing_and_conversion(
         )
     )
 
-    rendered = await RecursiveRenderer().render(md_component_with_renderer)
+    rendered = await BaselineRenderer().render(md_component_with_renderer)
     assert rendered == "\n".join(
         (
             "<div >",

--- a/tests/test_renderer_comparison.py
+++ b/tests/test_renderer_comparison.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from htmy import ErrorBoundary, Fragment, Renderer, component, html
+from htmy.renderer import RecursiveRenderer
+
+if TYPE_CHECKING:
+    from htmy import Component, ComponentType, Context
+
+# -- Sync and async page.
+
+
+@component
+def page(content: ComponentType, context: Context) -> Component:
+    return (
+        html.DOCTYPE.html,
+        html.html(
+            html.head(
+                html.title("Test page"),
+                html.meta.charset(),
+                html.meta.viewport(),
+                html.script(src="https://cdn.tailwindcss.com"),
+                html.link.css("https://cdn.jsdelivr.net/npm/daisyui@4.12.11/dist/full.min.css"),
+            ),
+            html.body(
+                content,
+                class_="h-screen w-screen",
+            ),
+            lang="en",
+        ),
+    )
+
+
+@component
+async def a_page(content: ComponentType, context: Context) -> Component:
+    return (
+        html.DOCTYPE.html,
+        html.html(
+            html.head(
+                html.title("Test page"),
+                html.meta.charset(),
+                html.meta.viewport(),
+                html.script(src="https://cdn.tailwindcss.com"),
+                html.link.css("https://cdn.jsdelivr.net/npm/daisyui@4.12.11/dist/full.min.css"),
+            ),
+            html.body(
+                content,
+                class_="h-screen w-screen",
+            ),
+            lang="en",
+        ),
+    )
+
+
+# -- Utils
+
+
+class WrapAsync:
+    def __init__(self, *children: ComponentType) -> None:
+        self.children = children
+
+    async def htmy(self, context: Context) -> Component:
+        return self.children
+
+
+class Nested:
+    def __init__(self, *children: ComponentType) -> None:
+        self.children = children
+
+    def htmy(self, context: Context) -> Component:
+        return html.div(
+            "Foo",
+            html.div("bar"),
+            Fragment(
+                html.div(
+                    WrapAsync("Before error", html.div(*self.children), "After error"),
+                )
+            ),
+        )
+
+
+def sync_async_divs(i: int) -> Fragment:
+    return Fragment(html.div(f"Sync {i}", " ", "end"), WrapAsync(html.div("Async {i}", " ", "end")))
+
+
+# -- Sync and async error components.
+
+
+class SyncError:
+    def htmy(self, context: Context) -> Component:
+        raise ValueError("sync-error-component")
+
+
+class AsyncError:
+    async def htmy(self, context: Context) -> Component:
+        raise ValueError("async-error-component")
+
+
+# -- Tests
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("component",),
+    (
+        # -- Render a component sequence directly.
+        ([Nested(sync_async_divs(i)) for i in range(100)],),
+        # -- Render a larger, nested component tree.
+        (page(Fragment(*[Nested(sync_async_divs(i)) for i in range(100)])),),
+        # -- Error boundary
+        (Nested(ErrorBoundary(Nested(SyncError()), fallback="Fallback to sync error.")),),
+        (Nested(ErrorBoundary(Nested(AsyncError()), fallback="Fallback to async error.")),),
+    ),
+)
+async def test_renderers(
+    *,
+    component: Component,
+    default_renderer: Renderer,
+    recursive_renderer: RecursiveRenderer,
+) -> None:
+    default_renderer_result = await default_renderer.render(component)
+    recursive_renderer_result = await recursive_renderer.render(component)
+    assert default_renderer_result == recursive_renderer_result

--- a/tests/test_renderer_comparison.py
+++ b/tests/test_renderer_comparison.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from htmy import ErrorBoundary, Fragment, Renderer, component, html
-from htmy.renderer import RecursiveRenderer
+from htmy.renderer import BaselineRenderer
 
 if TYPE_CHECKING:
     from htmy import Component, ComponentType, Context
@@ -119,8 +119,8 @@ async def test_renderers(
     *,
     component: Component,
     default_renderer: Renderer,
-    recursive_renderer: RecursiveRenderer,
+    baseline_renderer: BaselineRenderer,
 ) -> None:
     default_renderer_result = await default_renderer.render(component)
-    recursive_renderer_result = await recursive_renderer.render(component)
-    assert default_renderer_result == recursive_renderer_result
+    baseline_renderer_result = await baseline_renderer.render(component)
+    assert default_renderer_result == baseline_renderer_result

--- a/tests/test_snippet.py
+++ b/tests/test_snippet.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from htmy import HTMY, Context, SafeStr, Snippet, Text
+from htmy import Context, Renderer, Snippet, Text
 from htmy.typing import TextProcessor
 
 from .utils import tests_root
@@ -56,6 +56,6 @@ async def test_snippet(
     path_or_text: Text | str | Path, text_processor: TextProcessor, expected: str
 ) -> None:
     snippet = Snippet(path_or_text, text_processor=text_processor)
-    rendered = await HTMY().render(snippet)
-    assert isinstance(rendered, SafeStr)
+    rendered = await Renderer().render(snippet)
+    assert isinstance(rendered, str)
     assert rendered == expected


### PR DESCRIPTION
Plus related refactoring, more tests, documentation update.

Major changes:

- `htmy.HTMY` should be considered deprecated and replaced by `htmy.Renderer`.
- `htmy.Renderer` is a completely new renderer implementation with 2-6x performance compared to the renderer in version `0.3.6`, largely depending of course the use-case.
- `htmy.renderer` is now a package that offers the default `Renderer` of the lib, and also a `BaselineRenderer` (the original renderer of the lib). The reason for keeping the latter is its simplicity and easy to prove correctness. It can be used for debugging, testing, benchmarking other implementations.
- There are a number of new tests and test utilities for easily constructing deep, varied component trees for renderer testing and benchmarking.
- The documentation has been updated to follow up all these changes.

Regarding performance, the improvement you can expect strongly depends on the composition and depth of your component tree. The 2-6x improvement (compared to `0.3.6`) can be expected for component trees that have a mixture of sync components, async components, and `ErrorBoundary`s. Some general recommendations:

- Sync components can be resolved faster, so (as recommended in the docs) if a component doesn't need to be async, don't make it async.
- Less nesting improves performance. If a component is mostly "boilerplate" (some HTML layout with dynamic content in a couple of places), then you could consider using `Snippet` instead with a `text_processor` to fill in the dynamic parts.
- `ErrorBoundary` components can be relatively expensive, use them only where they are necessary.

With the tips above, you can potentially expect even better performance. This will still be considerably slower than Jinja for example, but there is no free lunch. For really performance critical parts, you could still create a wrapper component that uses a different rendering engine internally and return its result as a `SafeStr`.