### PR TITLE
Slot support in Snippet and MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ user_table = html.table(
 `htmy` has a rich set of built-in utilities and components for both HTML and other use-cases:
 
 - `html` module: a complete set of [baseline HTML tags](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility).
+- `Snippet`: utility for creating dynamic, customizable document snippets in their native file format (HTML, XML, Markdown, etc.), with slot support.
 - `md`: `MarkdownParser` utility and `MD` component for loading, parsing, converting, and rendering markdown content.
 - `i18n`: utilities for async, JSON based internationalization.
 - `BaseTag`, `TagWithProps`, `Tag`, `WildcardTag`: base classes for custom XML tags.
 - `ErrorBoundary`, `Fragment`, `SafeStr`, `WithContext`: utilities for error handling, component wrappers, context providers, and formatting.
-- `Snippet`: utility class for loading and customizing document snippets from the file system.
 - `etree.ETreeConverter`: utility that converts XML to a component tree with support for custom HTMY components.
 
 ### Rendering

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ user_table = html.table(
 `htmy` has a rich set of built-in utilities and components for both HTML and other use-cases:
 
 - `html` module: a complete set of [baseline HTML tags](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility).
-- `Snippet`: utility for creating dynamic, customizable document snippets in their native file format (HTML, XML, Markdown, etc.), with slot support.
+- `Snippet` and `Slots`: utilities for creating dynamic, customizable document snippets in their native file format (HTML, XML, Markdown, etc.), with slot rendering support.
 - `md`: `MarkdownParser` utility and `MD` component for loading, parsing, converting, and rendering markdown content.
 - `i18n`: utilities for async, JSON based internationalization.
 - `BaseTag`, `TagWithProps`, `Tag`, `WildcardTag`: base classes for custom XML tags.

--- a/docs/api/snippet.md
+++ b/docs/api/snippet.md
@@ -1,0 +1,4 @@
+# ::: htmy.snippet
+
+    options:
+        show_root_heading: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,11 +142,11 @@ user_table = html.table(
 `htmy` has a rich set of built-in utilities and components for both HTML and other use-cases:
 
 - `html` module: a complete set of [baseline HTML tags](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility).
+- `Snippet`: utility for creating dynamic, customizable document snippets in their native file format (HTML, XML, Markdown, etc.), with slot support.
 - `md`: `MarkdownParser` utility and `MD` component for loading, parsing, converting, and rendering markdown content.
 - `i18n`: utilities for async, JSON based internationalization.
 - `BaseTag`, `TagWithProps`, `Tag`, `WildcardTag`: base classes for custom XML tags.
 - `ErrorBoundary`, `Fragment`, `SafeStr`, `WithContext`: utilities for error handling, component wrappers, context providers, and formatting.
-- `Snippet`: utility class for loading and customizing document snippets from the file system.
 - `etree.ETreeConverter`: utility that converts XML to a component tree with support for custom HTMY components.
 
 ### Rendering

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,7 +142,7 @@ user_table = html.table(
 `htmy` has a rich set of built-in utilities and components for both HTML and other use-cases:
 
 - `html` module: a complete set of [baseline HTML tags](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility).
-- `Snippet`: utility for creating dynamic, customizable document snippets in their native file format (HTML, XML, Markdown, etc.), with slot support.
+- `Snippet` and `Slots`: utilities for creating dynamic, customizable document snippets in their native file format (HTML, XML, Markdown, etc.), with slot rendering support.
 - `md`: `MarkdownParser` utility and `MD` component for loading, parsing, converting, and rendering markdown content.
 - `i18n`: utilities for async, JSON based internationalization.
 - `BaseTag`, `TagWithProps`, `Tag`, `WildcardTag`: base classes for custom XML tags.

--- a/htmy/__init__.py
+++ b/htmy/__init__.py
@@ -5,7 +5,6 @@ from .core import Formatter as Formatter
 from .core import Fragment as Fragment
 from .core import SafeStr as SafeStr
 from .core import SkipProperty as SkipProperty
-from .core import Snippet as Snippet
 from .core import Tag as Tag
 from .core import TagConfig as TagConfig
 from .core import TagWithProps as TagWithProps
@@ -16,6 +15,8 @@ from .core import XBool as XBool
 from .core import component as component
 from .core import xml_format_string as xml_format_string
 from .renderer import Renderer as Renderer
+from .snippet import Slots as Slots
+from .snippet import Snippet as Snippet
 from .typing import AsyncComponent as AsyncComponent
 from .typing import AsyncContextProvider as AsyncContextProvider
 from .typing import AsyncFunctionComponent as AsyncFunctionComponent
@@ -34,7 +35,9 @@ from .typing import PropertyValue as PropertyValue
 from .typing import SyncComponent as SyncComponent
 from .typing import SyncContextProvider as SyncContextProvider
 from .typing import SyncFunctionComponent as SyncFunctionComponent
-from .typing import is_component_sequence as is_component_sequence
+from .utils import as_component_sequence as as_component_sequence
+from .utils import as_component_type as as_component_type
+from .utils import is_component_sequence as is_component_sequence
 from .utils import join_components as join_components
 
 HTMY = Renderer

--- a/htmy/renderer/default.py
+++ b/htmy/renderer/default.py
@@ -6,7 +6,8 @@ from collections.abc import Awaitable, Callable, Iterator
 from typing import TypeAlias
 
 from htmy.core import ErrorBoundary, xml_format_string
-from htmy.typing import Component, ComponentType, Context, ContextProvider, is_component_sequence
+from htmy.typing import Component, ComponentType, Context, ContextProvider
+from htmy.utils import is_component_sequence
 
 
 class _Node:

--- a/htmy/snippet.py
+++ b/htmy/snippet.py
@@ -1,0 +1,259 @@
+import re
+from collections.abc import Awaitable, Iterator, Mapping
+from pathlib import Path
+
+from .core import SafeStr, Text
+from .io import open_file
+from .typing import (
+    Component,
+    ComponentType,
+    Context,
+    TextProcessor,
+    TextResolver,
+)
+from .utils import as_component_sequence, as_component_type, is_component_sequence
+
+# -- Components and utilities
+
+
+class Slots:
+    """
+    Utility that resolves slots in a string input to components.
+
+    More technically, it splits a string into slot and non-slot parts, replaces the
+    slot parts with the corresponding components (which may be component sequences)
+    from the given slot mapping, and returns the resulting component sequence.
+
+    The default slot placeholder is a standard XML/HTML comment of the following form:
+    `<!-- slot[slot-key] -->`. Any number of whitespaces (including 0) are allowed in
+    the placeholder, but the slot key must not contain any whitespaces. For details, see
+    `Slots.slot_re`.
+
+    Besides the pre-defined regular expressions in `Slots.slot_re`, any other regular
+    expression can be used to identify slots as long as it meets the requirements described
+    in `Slots.slots_re`.
+
+    Implements: `htmy.typing.TextResolver`
+    """
+
+    __slots__ = ("_slot_mapping", "_slot_re", "_not_found")
+
+    class slot_re:
+        """
+        Slot regular expressions.
+
+        Requirements:
+
+        - The regular expression must have exactly one capturing group that captures the slot key.
+        """
+
+        square_bracket = re.compile(r"<!-- *slot *\[ *([^[ ]+) *\] *-->")
+        """
+        Slot regular expression that matches slots defined as follows: `<!-- slot[slot-key] -->`.
+
+        The slot key must not contain any whitespaces and there must not be any additional text
+        in the XML/HTML comment. Any number of whitespaces (including 0) are allowed around the
+        parts of the slot placeholder.
+        """
+        parentheses = re.compile(r"<!-- *slot *\( *([^( ]+) *\) *-->")
+        """
+        Slot regular expression that matches slots defined as follows: `<!-- slot(slot-key) -->`.
+
+        The slot key must not contain any whitespaces and there must not be any additional text
+        in the XML/HTML comment. Any number of whitespaces (including 0) are allowed around the
+        parts of the slot placeholder.
+        """
+
+        # There are no defaults for angle bracket and curly braces, because
+        # they may conflict with HTML and format strings.
+
+        default = square_bracket
+        """
+        The default slot regular expression. Same as `Slots.slot_re.square_bracket`.
+        """
+
+    def __init__(
+        self,
+        slot_mapping: Mapping[str, Component],
+        *,
+        slot_re: re.Pattern[str] = slot_re.default,
+        not_found: Component | None = None,
+    ) -> None:
+        """
+        Initialization.
+
+        Slot regular expressions are used to find slot keys in strings, which are then replaced
+        with the corresponding component from the slot mapping. `slot_re` must have exactly one
+        capturing group that captures the slot key. `Slots.slot_re` contains some predefined slot
+        regular expressions, but any other regular expression can be used as long as it matches
+        the capturing group requirement above.
+
+        Arguments:
+            slot_mapping: Slot mapping the maps slot keys to the corresponding component.
+            slot_re: The slot regular expression that is used to find slot keys in strings.
+            not_found: The component that is used to replace slot keys that are not found in
+                `slot_mapping`. If `None` and the slot key is not found in `slot_mapping`,
+                then a `KeyError` will be raised by `resolve()`.
+        """
+        self._slot_mapping = slot_mapping
+        self._slot_re = slot_re
+        self._not_found = not_found
+
+    def resolve_text(self, text: str) -> Component:
+        """
+        Resolves the given string into components using the instance's slot regular expression
+        and slot mapping.
+
+        Arguments:
+            text: The text to resolve.
+
+        Returns:
+           The component sequence the text resolves to.
+
+        Raises:
+            KeyError: If a slot key is not found in the slot mapping and `not_found` is `None`.
+        """
+        return tuple(self._resolve_text(text))
+
+    def _resolve_text(self, text: str) -> Iterator[ComponentType]:
+        """
+        Generator that yields the slot and non-slot parts of the given string in order.
+
+        Arguments:
+            text: The text to resolve.
+
+        Yields:
+            The slot and non-slot parts of the given string.
+
+        Raises:
+            KeyError: If a slot key is not found in the slot mapping and `not_found` is `None`.
+        """
+        is_slot = False
+        # The implementation requires that the slot regular expression has exactly one capturing group.
+        for part in self._slot_re.split(text):
+            if is_slot:
+                resolved = self._slot_mapping.get(part, self._not_found)
+                if resolved is None:
+                    raise KeyError(f"Component not found for slot: {part}")
+
+                if is_component_sequence(resolved):
+                    yield from resolved
+                else:
+                    # mypy complains that resolved may be a sequence, but that's not the case.
+                    yield resolved  # type: ignore[misc]
+            else:
+                yield part
+
+            is_slot = not is_slot
+
+
+class Snippet:
+    """
+    Component that renders text, which may be asynchronously loaded from a file.
+
+    The entire snippet processing pipeline consists of the following steps:
+
+    1. The text content is loaded from a file or passed directly as a `Text` instance.
+    2. The text content is processed by a `TextProcessor` if provided.
+    3. The processed text is converted into a component (may be component sequence)
+       by a `TextResolver`, for example `Slots`.
+    4. Every `str` children (produced by the steps above) is converted into a `SafeStr` for
+       rendering.
+
+    The pipeline above is a bit abstract, so here are some usage notes:
+
+    - The text content of a snippet can be a Python format string template, in which case the
+      `TextProcessor` can be a simple method that calls `str.format()` with the correct arguments.
+    - Alternatively, a text processor can also be used to get only a substring -- commonly referred
+      to as fragment in frameworks like Jinja -- of the original text.
+    - The text processor is applied before the text resolver, which makes it possible to insert
+      placeholders into the text (for example slots, like in this case:
+      `..."{toolbar}...".format(toolbar="<!-- slot[toolbar] -->")`) that are then replaced with any
+      `htmy.Component` by the `TextResolver` (for example `Slots`).
+    - `TextResolver` can return plain `str` values, it is not necessary for it to convert strings
+      to `SafeStr` to prevent unwanted escaping.
+
+    Example:
+
+    ```python
+    from datetime import date
+    from htmy import Snippet, Slots
+
+    def text_processor(text: str, context: Context) -> str:
+       return text.format(today=date.today())
+
+    snippet = Snippet(
+        "my-page.html",
+        text_processor=text_processor,
+        text_resolver=Slots(
+            {
+                "date-picker": MyDatePicker(class_="text-primary"),
+                "Toolbar": MyPageToolbar(active_page="home"),
+                ...
+            }
+        ),
+    )
+    ```
+
+    In the above example, if `my-page.html` contains a `{today}` placeholder, it will be replaced
+    with the current date. If it contains a `<!-- slot[toolbar] -->}` slot, then the `MyPageToolbar`
+    `htmy` component instance will be rendered in its place, and the `<!-- slot[date-picker] -->` slot
+    will be replaced with the `MyDatePicker` component instance.
+    """
+
+    __slots__ = ("_path_or_text", "_text_processor", "_text_resolver")
+
+    def __init__(
+        self,
+        path_or_text: Text | str | Path,
+        text_resolver: TextResolver | None = None,
+        *,
+        text_processor: TextProcessor | None = None,
+    ) -> None:
+        """
+        Initialization.
+
+        Arguments:
+            path_or_text: The path from where the content should be loaded or a `Text`
+                instance if this value should be rendered directly.
+            text_resolver: An optional `TextResolver` (e.g. `Slots`) that converts the processed
+                text into a component. If not provided, the text will be rendered as a `SafeStr`.
+            text_processor: An optional `TextProcessor` that can be used to process the text
+                content before rendering. It can be used for example for token replacement or
+                string formatting.
+        """
+        self._path_or_text = path_or_text
+        self._text_processor = text_processor
+        self._text_resolver = text_resolver
+
+    async def htmy(self, context: Context) -> Component:
+        """Renders the component."""
+        text = await self._get_text_content()
+        if self._text_processor is not None:
+            processed = self._text_processor(text, context)
+            text = (await processed) if isinstance(processed, Awaitable) else processed
+
+        if self._text_resolver is None:
+            return self._render_text(text, context)
+
+        comps = as_component_sequence(self._text_resolver.resolve_text(text))
+        return tuple(
+            as_component_type(self._render_text(c, context)) if isinstance(c, str) else c for c in comps
+        )
+
+    async def _get_text_content(self) -> str:
+        """Returns the plain text content that should be rendered."""
+        path_or_text = self._path_or_text
+
+        if isinstance(path_or_text, Text):
+            return path_or_text
+        else:
+            async with await open_file(path_or_text, "r") as f:
+                return await f.read()
+
+    def _render_text(self, text: str, context: Context) -> Component:
+        """
+        Render function that takes the text that must be rendered and the current rendering context,
+        and returns the corresponding component.
+        """
+        return SafeStr(text)

--- a/htmy/typing.py
+++ b/htmy/typing.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Coroutine, Mapping, MutableMapping
-from typing import Any, Protocol, TypeAlias, TypeGuard, TypeVar, runtime_checkable
+from typing import Any, Protocol, TypeAlias, TypeVar, runtime_checkable
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -66,11 +66,6 @@ Component: TypeAlias = ComponentType | ComponentSequence
 """Component type: a single component or a sequence of components."""
 
 
-def is_component_sequence(obj: Any) -> TypeGuard[ComponentSequence]:
-    """Returns whether the given object is a component sequence."""
-    return isinstance(obj, (list, tuple))
-
-
 SyncFunctionComponent: TypeAlias = Callable[[T, Context], Component]
 """Protocol definition for sync function components."""
 
@@ -104,8 +99,25 @@ class AsyncContextProvider(Protocol):
 ContextProvider: TypeAlias = SyncContextProvider | AsyncContextProvider
 """Context provider type."""
 
-
 # -- Text processors
 
 TextProcessor: TypeAlias = Callable[[str, Context], str | Coroutine[Any, Any, str]]
 """Callable type that expects a string and a context, and returns a processed string."""
+
+
+class TextResolver(Protocol):
+    """
+    Protocol definition for resolvers that convert a string to a component.
+    """
+
+    def resolve_text(self, text: str) -> Component:
+        """
+        Returns the resolved component for the given text.
+
+        Arguments:
+            text: The text to resolve.
+
+        Raises:
+            KeyError: If the text cannot be resolved to a component.
+        """
+        ...

--- a/htmy/utils.py
+++ b/htmy/utils.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeGuard
 
 if TYPE_CHECKING:
-    from .typing import ComponentSequence, ComponentType
+    from .typing import Component, ComponentSequence, ComponentType
 
 
 def join_components(
@@ -42,3 +42,22 @@ def join(*items: str | None, separator: str = " ") -> str:
     Joins the given strings with the given separator, skipping `None` values.
     """
     return separator.join(i for i in items if i)
+
+
+def is_component_sequence(comp: Component) -> TypeGuard[ComponentSequence]:
+    """Returns whether the given component is a component sequence."""
+    return isinstance(comp, (list, tuple))
+
+
+def as_component_sequence(comp: Component) -> ComponentSequence:
+    """Returns the given component as a component sequence."""
+    # mypy doesn't understand the `is_component_sequence` type guard.
+    return comp if is_component_sequence(comp) else (comp,)  # type: ignore[return-value]
+
+
+def as_component_type(comp: Component) -> ComponentType:
+    """Returns the given component as a `ComponentType` (not sequence)."""
+    from .core import Fragment
+
+    # mypy doesn't understand the `is_component_sequence` type guard.
+    return comp if not is_component_sequence(comp) else Fragment(*comp)  # type: ignore[return-value]

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -54,6 +54,7 @@ nav:
           - api/renderer/default.md
           - api/renderer/baseline.md
       - HTML: api/html.md
+      - Snippet: api/snippet.md
       - Markdown: api/md.md
       - I18n: api/i18n.md
       - api/utils.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ markdown = "^3.7"
 [tool.poetry.group.dev.dependencies]
 mkdocs-material = "^9.5.39"
 mkdocstrings = {extras = ["python"], version = "^0.26.1"}
-mypy = "^1.11.2"
+mypy = "^1.14.1"
 poethepoet = "^0.29.0"
 pytest = "^8.3.3"
 pytest-asyncio = "^0.24.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "htmy"
-version = "0.4.2"
+version = "0.5.0"
 description = "Async, pure-Python rendering engine."
 authors = ["Peter Volf <do.volfp@gmail.com>"]
 license = "MIT"

--- a/tests/test_snippet.py
+++ b/tests/test_snippet.py
@@ -1,9 +1,11 @@
+import re
 from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
 import pytest
 
-from htmy import Context, Renderer, Snippet, Text
+from htmy import Component, ComponentType, Context, Renderer, SafeStr, Slots, Snippet, Text, html
 from htmy.typing import TextProcessor
 
 from .utils import tests_root
@@ -21,6 +23,19 @@ _hello_world_format_snippet = "\n".join(
 _hello_world_snippet = _hello_world_format_snippet.format(
     message="The quick brown fox jumps over the lazy dog."
 )
+
+
+def message_to_slot_text_processor(text: str, ctx: Context) -> str:
+    # Replace {message} with some text and a message and a signature slot.
+    return text.format(
+        message=(
+            "before message slot "
+            "<!-- slot[message] -->"
+            " between slots "
+            "<!-- slot[signature] -->"
+            " after signature slot"
+        )
+    )
 
 
 def sync_text_processor(text: str, context: Context) -> str:
@@ -59,3 +74,165 @@ async def test_snippet(
     rendered = await Renderer().render(snippet)
     assert isinstance(rendered, str)
     assert rendered == expected
+
+
+class _SlotTexts:
+    slot_mapping: dict[str, Component] = {
+        "s1": [html.p("slot-one-part-one", class_="s1"), html.p("slot-one-part-two", class_="s1")],
+        "s2": html.p("slot-two-replacement", class_="s2"),
+    }
+    not_found_component = "not-found"
+    full_slot_mapping: dict[str, Component] = {
+        **slot_mapping,
+        "s3": not_found_component,
+    }
+
+    base = (
+        "one   <!--slot {open} s1   {close} --> two <!-- slot{open}s2{close}-->"
+        "<!-- slot{open} s2{close} -->   <!--   slot{open}s3 {close} -->"
+    )
+
+    split = ["one   ", "s1", " two ", "s2", "", "s2", "   ", "s3", ""]
+    mapped_split = (
+        "one   ",
+        *cast(list[ComponentType], full_slot_mapping["s1"]),
+        " two ",
+        full_slot_mapping["s2"],
+        "",
+        full_slot_mapping["s2"],
+        "   ",
+        full_slot_mapping["s3"],
+        "",
+    )
+
+    square_bracket = base.format(open="[", close="]")
+    parentheses = base.format(open="(", close=")")
+
+
+@pytest.mark.parametrize(
+    ("text", "split_re", "expected"),
+    (
+        # -- Square bracket text
+        (_SlotTexts.square_bracket, Slots.slot_re.default, _SlotTexts.split),  # Test default
+        (_SlotTexts.square_bracket, Slots.slot_re.square_bracket, _SlotTexts.split),
+        (_SlotTexts.square_bracket, Slots.slot_re.parentheses, None),
+        # -- Parentheses text
+        (_SlotTexts.parentheses, Slots.slot_re.default, None),  # Test default
+        (_SlotTexts.parentheses, Slots.slot_re.square_bracket, None),
+        (_SlotTexts.parentheses, Slots.slot_re.parentheses, _SlotTexts.split),
+    ),
+)
+def test_slots_re(text: str, split_re: re.Pattern[str], expected: list[str] | None) -> None:
+    result = split_re.split(text)
+    if expected is None:
+        assert len(result) == 1
+        assert result[0] == text
+    else:
+        assert result == expected
+
+
+def test_default_slot_re() -> None:
+    assert Slots.slot_re.default is Slots.slot_re.square_bracket
+
+
+@pytest.mark.parametrize(
+    ("slots", "text", "expected"),
+    (
+        # -- Square bracket text
+        (
+            Slots(
+                _SlotTexts.slot_mapping,
+                not_found=_SlotTexts.not_found_component,
+            ),
+            _SlotTexts.square_bracket,
+            _SlotTexts.mapped_split,
+        ),
+        (
+            Slots(
+                _SlotTexts.slot_mapping,
+                slot_re=Slots.slot_re.square_bracket,
+                not_found=_SlotTexts.not_found_component,
+            ),
+            _SlotTexts.square_bracket,
+            _SlotTexts.mapped_split,
+        ),
+        (
+            Slots(
+                _SlotTexts.slot_mapping,
+                slot_re=Slots.slot_re.parentheses,
+            ),
+            _SlotTexts.square_bracket,
+            None,
+        ),
+        # -- Parentheses text
+        (
+            Slots(
+                _SlotTexts.slot_mapping,
+            ),
+            _SlotTexts.parentheses,
+            None,
+        ),
+        (
+            Slots(
+                _SlotTexts.slot_mapping,
+                slot_re=Slots.slot_re.square_bracket,
+            ),
+            _SlotTexts.parentheses,
+            None,
+        ),
+        (
+            Slots(
+                _SlotTexts.slot_mapping,
+                not_found=_SlotTexts.not_found_component,
+                slot_re=Slots.slot_re.parentheses,
+            ),
+            _SlotTexts.parentheses,
+            _SlotTexts.mapped_split,
+        ),
+    ),
+)
+def test_slots(slots: Slots, text: str, expected: list[str] | None) -> None:
+    result = slots.resolve_text(text)
+    if expected is None:
+        assert isinstance(result, tuple)
+        assert len(result) == 1
+        assert result[0] == text
+    else:
+        assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_snippet_with_text_processor_and_slots() -> None:
+    slot_mapping = {
+        "message": html.p("Hope you're having fun."),
+        "signature": html.p("Cheers, htmy"),
+    }
+    snippet = Snippet(
+        Text(_hello_world_format_snippet),
+        Slots(slot_mapping),
+        text_processor=message_to_slot_text_processor,
+    )
+    formatted_text = message_to_slot_text_processor(_hello_world_format_snippet, {})
+    children = await snippet.htmy({})
+    assert isinstance(children, tuple)
+    assert children == (
+        formatted_text[: formatted_text.index("before message slot ") + len("before message slot ")],
+        slot_mapping["message"],
+        " between slots ",
+        slot_mapping["signature"],
+        formatted_text[formatted_text.index(" after signature slot") :],
+    )
+    assert isinstance(children[0], SafeStr)
+    assert isinstance(children[2], SafeStr)
+    assert isinstance(children[4], SafeStr)
+
+    rendered = await Renderer().render(snippet)
+    assert rendered == _hello_world_format_snippet.format(
+        message=(
+            "before message slot "
+            "<p >Hope you're having fun.</p>"
+            " between slots "
+            "<p >Cheers, htmy</p>"
+            " after signature slot"
+        )
+    )


### PR DESCRIPTION
Implements #32

Changes:

- Added support for slot rendering to `Snippet` and `MD`. Actually the protocols/interfaces are very flexible, they allow a lot more, for example fragment rendering or Jinja include-like features, but `Slots` is the only built-in implementation right now. 
- Added some new utilities to complement `s_component_sequence()`: `as_component_sequence()` and `as_component_type()`. They are built-in solutions to a common issue, making it easy to create a correct component is hierarchy and not have to deal with the "component list in list" topic.
- Added more `Snippet` and `MD` tests.
- Added more documentation.