### PR TITLE
Feature: use lxml if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ The package is available on PyPI and can be installed with:
 $ pip install htmy
 ```
 
+The package has the following optional dependencies:
+
+- `lxml` *(recommended)*: It is prioritized over `xml.etree.ElementTree` if installed, and provides more secure, faster, and more flexible HTML and XML processing. Used for example for markdown processing. Install with `pip install htmy[lxml]`.
+
 ## Concepts
 
 The entire library -- from the rendering engine itself to the built-in components -- is built around a few simple protocols and a handful of simple utility classes. This means that you can easily customize, extend, or replace basically everything in the library. Yes, even the rendering engine. The remaining parts will keep working as expected.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ pip install htmy
 
 The package has the following optional dependencies:
 
-- `lxml` *(recommended)*: It is prioritized over `xml.etree.ElementTree` if installed, and provides more secure, faster, and more flexible HTML and XML processing. Used for example for markdown processing. Install with `pip install htmy[lxml]`.
+- `lxml` *(recommended)*: When installed, it is prioritized over `xml.etree.ElementTree` and provides more secure, faster, and more flexible HTML and XML processing. It is used, for example, for Markdown processing. Install with: `pip install "htmy[lxml]"`.
 
 ## Concepts
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,10 @@ The package is available on PyPI and can be installed with:
 $ pip install htmy
 ```
 
+The package has the following optional dependencies:
+
+- `lxml` *(recommended)*: It is prioritized over `xml.etree.ElementTree` if installed, and provides more secure, faster, and more flexible HTML and XML processing. Used for example for markdown processing. Install with `pip install htmy[lxml]`.
+
 ## Concepts
 
 The entire library -- from the rendering engine itself to the built-in components -- is built around a few simple protocols and a handful of simple utility classes. This means that you can easily customize, extend, or replace basically everything in the library. Yes, even the rendering engine. The remaining parts will keep working as expected.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ $ pip install htmy
 
 The package has the following optional dependencies:
 
-- `lxml` *(recommended)*: It is prioritized over `xml.etree.ElementTree` if installed, and provides more secure, faster, and more flexible HTML and XML processing. Used for example for markdown processing. Install with `pip install htmy[lxml]`.
+- `lxml` *(recommended)*: When installed, it is prioritized over `xml.etree.ElementTree` and provides more secure, faster, and more flexible HTML and XML processing. It is used, for example, for Markdown processing. Install with: `pip install "htmy[lxml]"`.
 
 ## Concepts
 

--- a/htmy/etree.py
+++ b/htmy/etree.py
@@ -1,23 +1,34 @@
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
-from collections.abc import Callable, Generator
 from typing import TYPE_CHECKING, ClassVar
 from xml.sax.saxutils import unescape
 
-if TYPE_CHECKING:
-    from collections.abc import Mapping
-    from xml.etree.ElementTree import Element
+try:
+    from lxml.etree import tostring as etree_to_string
+    from lxml.etree._element import _Element as Element
+    from lxml.html import fragment_fromstring as etree_from_string
+except ImportError:
+    from xml.etree.ElementTree import Element  # type: ignore[assignment]
+    from xml.etree.ElementTree import fromstring as etree_from_string  # type: ignore[assignment]
+    from xml.etree.ElementTree import tostring as etree_to_string  # type: ignore[no-redef]
 
-    from htmy.typing import ComponentType, Properties
-
-
+from htmy import ComponentType, Properties
 from htmy.core import Fragment, SafeStr, WildcardTag
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Mapping
 
 
 class ETreeConverter:
     """
     Utility for converting XML strings to custom components.
+
+    By default the converter uses the standard library's `xml.etree.ElementTree`
+    module for string to element tree, and element tree to string conversion,
+    but if `lxml` is installed, it will be used instead.
+
+    Installing `lxml` is recommended for better performance and additional features,
+    like performance and support for broken HTML fragments.
     """
 
     __slots__ = ("_rules",)
@@ -43,15 +54,15 @@ class ETreeConverter:
             return SafeStr(element)
 
         element = f"<{self._htmy_fragment}>{element}</{self._htmy_fragment}>"
-        return self.convert_element(ET.fromstring(element))  # noqa: S314 # Only use from XML strings from a trusted source.
+        return self.convert_element(etree_from_string(element))  # noqa: S314 # Only use from XML strings from a trusted source.
 
     def convert_element(self, element: Element) -> ComponentType:
         """Converts the given `Element` to a component."""
         rules = self._rules
         if len(rules) == 0:
-            return SafeStr(ET.tostring(element))
+            return SafeStr(etree_to_string(element))
 
-        tag: str = element.tag
+        tag: str = element.tag  # type: ignore[assignment]
         component = Fragment if tag == self._htmy_fragment else rules.get(tag)
         children = self._convert_children(element)
         properties = self._convert_properties(element)

--- a/htmy/etree.py
+++ b/htmy/etree.py
@@ -28,7 +28,10 @@ class ETreeConverter:
     but if `lxml` is installed, it will be used instead.
 
     Installing `lxml` is recommended for better performance and additional features,
-    like performance and support for broken HTML fragments.
+    like performance and support for broken HTML fragments. **Important:** `lxml` is
+    far more lenient and flexible than the standard library, so having it installed is
+    not only a performance boost, but it may also slightly change the element conversion
+    behavior in certain edge-cases!
     """
 
     __slots__ = ("_rules",)

--- a/htmy/etree.py
+++ b/htmy/etree.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, ClassVar
 from xml.sax.saxutils import unescape
 
 try:
+    from lxml.etree import _Element as Element
     from lxml.etree import tostring as etree_to_string
-    from lxml.etree._element import _Element as Element
     from lxml.html import fragment_fromstring as etree_from_string
 except ImportError:
     from xml.etree.ElementTree import Element  # type: ignore[assignment]
@@ -57,13 +57,13 @@ class ETreeConverter:
             return SafeStr(element)
 
         element = f"<{self._htmy_fragment}>{element}</{self._htmy_fragment}>"
-        return self.convert_element(etree_from_string(element))  # noqa: S314 # Only use from XML strings from a trusted source.
+        return self.convert_element(etree_from_string(element))  # noqa: S314 # Only use XML strings from a trusted source.
 
     def convert_element(self, element: Element) -> ComponentType:
         """Converts the given `Element` to a component."""
         rules = self._rules
         if len(rules) == 0:
-            return SafeStr(etree_to_string(element))
+            return SafeStr(etree_to_string(element, encoding="unicode"))
 
         tag: str = element.tag  # type: ignore[assignment]
         component = Fragment if tag == self._htmy_fragment else rules.get(tag)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "htmy"
-version = "0.7.4"
+version = "0.8.0"
 description = "Async, pure-Python server-side rendering engine."
 authors = ["Peter Volf <do.volfp@gmail.com>"]
 license = "MIT"
@@ -10,21 +10,23 @@ readme = "README.md"
 python = "^3.10"
 anyio = "^4.6.2.post1"
 async-lru = "^2.0.4"
-markdown = "^3.7"
+markdown = "^3.8"
 
 [tool.poetry.group.dev.dependencies]
-mkdocs-material = "^9.5.39"
-mkdocstrings = { extras = ["python"], version = "^0.26.1" }
-mypy = "^1.15.0"
-poethepoet = "^0.29.0"
+fastapi = "^0.116.0"
+fasthx = "^2.3.3"
+lxml = "^6.0.0"
+mkdocs-material = "^9.6.16"
+mkdocstrings = { extras = ["python"], version = "^0.30.0" }
+mypy = "^1.17.0"
+poethepoet = "^0.37.0"
 pytest = "^8.3.3"
 pytest-asyncio = "^0.24.0"
 pytest-random-order = "^1.1.1"
-ruff = "^0.9.0"
-types-markdown = "^3.7.0.20240822"
+ruff = "^0.12.0"
+types-markdown = "^3.8.0.20250809"
 typing-extensions = "^4.12.2"
-fastapi = "^0.115.8"
-fasthx = "^2.2.1"
+types-lxml = "^2025.3.30"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,14 @@ python = "^3.10"
 anyio = "^4.6.2.post1"
 async-lru = "^2.0.4"
 markdown = "^3.8"
+lxml = { version = ">=6.0.0", optional = true }
+
+[tool.poetry.extras]
+lxml = ["lxml"]
 
 [tool.poetry.group.dev.dependencies]
 fastapi = "^0.116.0"
 fasthx = "^2.3.3"
-lxml = "^6.0.0"
 mkdocs-material = "^9.6.16"
 mkdocstrings = { extras = ["python"], version = "^0.30.0" }
 mypy = "^1.17.0"


### PR DESCRIPTION
Changes:

- Prefer `lxml` and its HTML parser if available. Otherwise fall back to standard library.
- Upgrade dev dependencies.
- Bump version in preparation for release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional lxml support for HTML/XML parsing/serialization; automatically used when installed, with seamless fallback to the standard library.
  * New public compatibility exports to simplify parsing/serialization and typing when lxml is present.
* **Documentation**
  * Added “Optional dependencies” guidance and install instructions for htmy[lxml].
* **Chores**
  * Bumped version to 0.8.0 and updated dependencies/tooling; added lxml as an optional extra.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->