### PR TITLE
Documentation: add notes about XSS prevention when using the MD component

### DIFF
--- a/docs/examples/markdown.md
+++ b/docs/examples/markdown.md
@@ -4,7 +4,7 @@ The focus of this example is markdown rendering and customization. As such, all 
 
 There's one important thing to know about markdown in relation to this tutorial and the markdown support in `htmy`: markdown can include [HTML](https://daringfireball.net/projects/markdown/syntax#html) (well, XML). Looking at this from another perspective, most HTML/XML snippets can be parsed by markdown parsers without issues. This means that while the below examples work with text files with markdown syntax, those file could also contain plain HTML snippets with no "markdown" at all. You will start to see the full power of this concept by the end of this article.
 
-**Important:** the `MD` component assumes that the processed markdown text is secure and does not contain any malicious code! When dealing with untrusted inputs, ensure it is safely escaped (using for example `htmy.xml_format_string`) before passing it to this component! Failing to do so leads to XSS vulnerabilities.
+**Warning:** The `MD` component treats its input as trusted. If any part of the input comes from untrusted sources, ensure it is safely escaped (using for example `htmy.xml_format_string`)! Passing untrusted input to the `MD` component leads to XSS vulnerabilities.
 
 ## Essentials
 
@@ -64,7 +64,7 @@ In this section we will extend the above example by adding custom rendering rule
 
 The `post.md` file can remain the same as above, but `app.py` will change quite a bit.
 
-First of all we need a few more import (although some only for typing):
+First of all we need a few more imports (although some only for typing):
 
 ```python
 from htmy import Component, ComponentType, Context, PropertyValue, Renderer, etree, html, md
@@ -166,7 +166,7 @@ If you run the app with `python app.py` now, you will see that the result is a c
 
 ## Custom components in markdown
 
-In the example above, you may have noticed that while we only defined custom conversion rules for HTML tags, we could have done the same for an other tag name, for example `"PostInfo"`. You can also have any XML in markdown files, for example `<PostInfo author="John" published_at="1971-10-11" />`. Obviously the browser will not know what to do with this tag if we blindly keep it, but with `htmy` we can process it in any way we want.
+In the example above, you may have noticed that while we only defined custom conversion rules for HTML tags, we could have done the same for another tag name, for example `"PostInfo"`. You can also have any XML in markdown files, for example `<PostInfo author="John" published_at="1971-10-11" />`. Obviously the browser will not know what to do with this tag if we blindly keep it, but with `htmy` we can process it in any way we want.
 
 Building on the code from the previous section, as an example, let's add this `PostInfo` tag to `post.md` and create a custom `htmy` component for it.
 

--- a/htmy/md/core.py
+++ b/htmy/md/core.py
@@ -22,7 +22,7 @@ class MarkdownParser(ContextAware):
     Context-aware markdown parser.
 
     By default, this class uses the `markdown` library with a sensible set of
-    [extensions](https://python-markdown.github.io/extensions/) including code highlighing.
+    [extensions](https://python-markdown.github.io/extensions/) including code highlighting.
     """
 
     __slots__ = ("_md",)
@@ -85,15 +85,14 @@ class MD(Snippet):
     It supports all the processing utilities of `Snippet`, including `text_resolver` and
     `text_processor` for formatting, token replacement, and slot conversion to components.
 
-    One note regaring slot convesion (`text_resolver`): it is executed before markdown parsing,
+    One note regarding slot conversion (`text_resolver`): it is executed before markdown parsing,
     and all string segments of the resulting component sequence are parsed individually by the
     markdown parser. As a consequence, you should only use slots in places where the preceding
     and following texts individually result in valid markdown.
 
-    **Important:** The component assumes that the processed markdown text is secure and
-    does not contain any malicious code! When dealing with untrusted inputs, ensure it
-    is safely escaped (using for example `htmy.xml_format_string`) before passing it
-    to this component. Failing to do so leads to XSS vulnerabilities.
+    **Warning:** The component treats its input as trusted. If any part of the input comes from
+    untrusted sources, ensure it is safely escaped (using for example `htmy.xml_format_string`)!
+    Passing untrusted input to this component leads to XSS vulnerabilities.
     """
 
     __slots__ = (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a security warning to the markdown component docs and examples clarifying that inputs are treated as trusted; untrusted content must be escaped before rendering to prevent XSS.
  - Provided guidance to use the project’s XML string formatter for escaping untrusted input.
  - Clarified typos in docstrings; no changes to runtime behavior, public APIs, or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->