### PR TITLE
Allow None in ComponentType

### DIFF
--- a/htmy/__init__.py
+++ b/htmy/__init__.py
@@ -31,12 +31,16 @@ from .typing import MutableContext as MutableContext
 from .typing import Properties as Properties
 from .typing import PropertyValue as PropertyValue
 from .typing import RendererType as RendererType
+from .typing import StrictComponentType as StrictComponentType
 from .typing import SyncComponent as SyncComponent
 from .typing import SyncContextProvider as SyncContextProvider
 from .utils import as_component_sequence as as_component_sequence
 from .utils import as_component_type as as_component_type
 from .utils import is_component_sequence as is_component_sequence
+from .utils import join
 from .utils import join_components as join_components
+
+join_classes = join
 
 HTMY = Renderer
 """Deprecated alias for `Renderer`."""

--- a/htmy/renderer/baseline.py
+++ b/htmy/renderer/baseline.py
@@ -73,16 +73,18 @@ class Renderer:
         """
         if isinstance(component, str):
             return self._string_formatter(component)
+        elif component is None:
+            return ""
         elif isinstance(component, Iterable):
             rendered_children = await asyncio.gather(
-                *(self._render_one(comp, context) for comp in component)
+                *(self._render_one(comp, context) for comp in component if comp is not None)
             )
 
-            return "".join(rendered_children)
+            return "".join(child for child in rendered_children if child is not None)
         else:
-            return await self._render_one(component, context)
+            return await self._render_one(component, context) or ""
 
-    async def _render_one(self, component: ComponentType, context: Context) -> str:
+    async def _render_one(self, component: ComponentType, context: Context) -> str | None:
         """
         Renders a single component.
 
@@ -95,6 +97,8 @@ class Renderer:
         """
         if isinstance(component, str):
             return self._string_formatter(component)
+        elif component is None:
+            return None
         else:
             child_context: Context = context
             if hasattr(component, "htmy_context"):  # isinstance() is too expensive.

--- a/htmy/typing.py
+++ b/htmy/typing.py
@@ -55,7 +55,10 @@ class AsyncComponent(Protocol):
 HTMYComponentType: TypeAlias = SyncComponent | AsyncComponent
 """Sync or async `htmy` component type."""
 
-ComponentType: TypeAlias = HTMYComponentType | str
+StrictComponentType: TypeAlias = HTMYComponentType | str
+"""Type definition for a single component that's not `None`."""
+
+ComponentType: TypeAlias = StrictComponentType | None
 """Type definition for a single component."""
 
 # Omit strings from this type to simplify checks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "htmy"
-version = "0.8.2"
+version = "0.9.0"
 description = "Async, pure-Python server-side rendering engine."
 authors = ["Peter Volf <do.volfp@gmail.com>"]
 license = "MIT"
@@ -21,12 +21,12 @@ fastapi = "^0.116.0"
 fasthx = "^2.3.3"
 mkdocs-material = "^9.6.16"
 mkdocstrings = { extras = ["python"], version = "^0.30.0" }
-mypy = "^1.17.0"
+mypy = "^1.18.2"
 poethepoet = "^0.37.0"
 pytest = "^8.3.3"
 pytest-asyncio = "^0.24.0"
 pytest-random-order = "^1.1.1"
-ruff = "^0.12.0"
+ruff = "^0.14.4"
 types-markdown = "^3.8.0.20250809"
 typing-extensions = "^4.12.2"
 types-lxml = "^2025.3.30"

--- a/tests/test_main_components.py
+++ b/tests/test_main_components.py
@@ -70,12 +70,14 @@ class Page:
             return f"async_fc-{Formatter.from_context(context).format_value(props)}"
 
         return WithContext(
+            None,
             a_main(
                 img(src="/example.png"),
                 tp(x="x1", y="y1", checked=XBool.true, required=XBool(True), value_skipped=XBool(False)),
                 sync_fc(987321),
                 async_fc(456),
                 a_main(
+                    None,
                     Formatter().in_context(
                         div(
                             AsyncText("sd<fs> df"),
@@ -89,21 +91,24 @@ class Page:
                             none=None,
                         )
                     ),
+                    None,
                     ErrorBoundary(
                         div(
+                            None,
                             ARaise(),
                         ),
-                        fallback=h1("Fallback after rendering error."),
+                        fallback=h1("Fallback after rendering error.", None),
                         errors={TypeError, ValueError},
                     ),
                 ),
-                div(),
+                div(ErrorBoundary(ARaise(), fallback=None)),
                 a_h2("something"),
                 div(AsyncText("something else"), div(AsyncText("inner something else"))),
                 p_1=123,
                 p_2="fls",
                 p_3=True,
             ),
+            None,
             context={**CustomTagFormatter().to_context(), "aio-sleep": 1},
         )
 
@@ -111,19 +116,22 @@ class Page:
     def rendered() -> str:
         return "\n".join(
             (
+                # \n-s in this tuple mark places where None children are ignored
+                # but still slightly mess up the output. The reason for not fixing
+                # these is because stricted None checks would impact performance.
                 '<a_main p-1="int:123" p-2="fls" p-3="true">',
                 '<img src="/example.png"/>',
                 '<tp x="x1" y="y1" checked="" required="" />',
                 "sync_fc-int:987321",
                 "async_fc-int:456",
-                "<a_main >",
+                "<a_main >\n",
                 '<div dp-1="123" class="w-full" >',
                 "sd&lt;fs&gt; df",
                 '<h1 created-at="2024-10-03T04:42:02.000071+00:00" on_day="2024-10-03">sdfds</h1>',
-                "</div>",
+                "</div>\n",
                 "<h1 >Fallback after rendering error.</h1>",
                 "</a_main>",
-                "<div ></div>",
+                "<div >\n\n</div>",
                 "<a_h2 >something</a_h2>",
                 "<div >",
                 "something else",


### PR DESCRIPTION
Changes:

- Allow `None` in the `ComponentType` type (and consequently in `Component`).
- Add new `StrictComponentType` in case someone needs it.
- Expose `htmy.utils.join` (a utility for joining CSS class names) as `htmy.join_classes`.
- Added tests for the new features.
- Updated dev dependencies.
