### PR TITLE
Remove async-lru dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,6 @@ The primary aim of `htmy` is to be a `Jinja` alternative that is similarly power
 The library aims to minimze its dependencies. Currently the following dependencies are required:
 
 - `anyio`: for async file operations and networking.
-- `async-lru`: for async caching.
 - `markdown`: for markdown parsing.
 
 ## Development

--- a/docs/index.md
+++ b/docs/index.md
@@ -355,7 +355,6 @@ The primary aim of `htmy` is to be a `Jinja` alternative that is similarly power
 The library aims to minimze its dependencies. Currently the following dependencies are required:
 
 - `anyio`: for async file operations and networking.
-- `async-lru`: for async caching.
 - `markdown`: for markdown parsing.
 
 ## Development

--- a/htmy/__init__.py
+++ b/htmy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 
 from .core import ContextAware as ContextAware
 from .core import Formatter as Formatter

--- a/htmy/i18n.py
+++ b/htmy/i18n.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, ClassVar, overload
 
-from async_lru import alru_cache
+from anyio.functools import lru_cache
 
 from .core import ContextAware
 from .io import open_file
@@ -112,7 +112,7 @@ class I18n(ContextAware):
         return result
 
 
-@alru_cache()
+@lru_cache()
 async def load_translation_resource(path: Path) -> TranslationResource:
     """
     Loads the translation resource from the given path.

--- a/htmy/snippet.py
+++ b/htmy/snippet.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator, Mapping
 from inspect import isawaitable
 from typing import TYPE_CHECKING
 
-from async_lru import alru_cache
+from anyio.functools import lru_cache
 
 from .core import SafeStr, Text
 from .io import load_text_file
@@ -260,7 +260,7 @@ class Snippet:
         if isinstance(path_or_text, Text):
             return path_or_text
         else:
-            return await Snippet._load_text_file(path_or_text)
+            return await Snippet._load_text_file(path_or_text)  # type: ignore[no-any-return]
 
     def _render_text(self, text: str, context: Context) -> Component:
         """
@@ -270,7 +270,7 @@ class Snippet:
         return SafeStr(text)
 
     @staticmethod
-    @alru_cache()
+    @lru_cache()
     async def _load_text_file(path: str | Path) -> str:
         """Async text loader with an LRU cache."""
         return await load_text_file(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "anyio>=4.7.0,<5",
-    "async-lru>=2.0.5,<3",
     "markdown>=3.8,<4",
 ]
 


### PR DESCRIPTION
Use `anyio` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated README and site to reflect current dependencies; removed an obsolete package from lists.
- Chores
  - Removed an unused runtime dependency from the project manifest.
  - Updated internal caching implementation with equivalent behavior (no user-facing impact).
  - Bumped version to 0.10.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->