### PR TITLE
Add make_context Jinja context customization option to JinjaTemplate

### DIFF
--- a/htmy/__init__.py
+++ b/htmy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 from .core import ContextAware as ContextAware
 from .core import Formatter as Formatter

--- a/htmy/jinja.py
+++ b/htmy/jinja.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Protocol
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
 
 import anyio
 from markupsafe import Markup
@@ -9,6 +9,9 @@ from markupsafe import Markup
 from .core import ContextAware, SafeStr
 from .renderer.context import RendererContext
 from .typing import Component, Context
+
+JinjaContextFactory: TypeAlias = Callable[[Context], Mapping[str, Any]]
+"""A function that builds additional Jinja context entries from an `htmy` rendering context."""
 
 if TYPE_CHECKING:
     from jinja2 import Template
@@ -87,15 +90,19 @@ class JinjaTemplate:
     If a `DefaultSlots` instance is found in the `htmy` rendering context, its slots are rendered
     and included in the `slots` context variable passed to Jinja. `slots` passed directly to this
     component take precedence over `DefaultSlots` slots when both contain a slot with the same name.
+
+    Jinja context creation precedence: `jinja_context`, `_build_context()`, `make_context`, and
+    finally the reserved `slots` key.
     """
 
-    __slots__ = ("_jinja_context", "_slots", "_template_name")
+    __slots__ = ("_jinja_context", "_make_context", "_slots", "_template_name")
 
     def __init__(
         self,
         template_name: str,
         *,
         jinja_context: Mapping[str, Any] | None = None,
+        make_context: JinjaContextFactory | None = None,
         slots: Mapping[str, Component] | None = None,
     ) -> None:
         """
@@ -104,13 +111,17 @@ class JinjaTemplate:
         Arguments:
             template_name: The name of the template to render.
             jinja_context: Optional mapping passed to Jinja as the template context.
-            slots: Optional named slots to be rendered in the template. Values are `htmy` components, they
-                are rendered before being passed to Jinja as `markupsafe.Markup` to avoid double-escaping,
-                content is not re-escaped by Jinja's autoescape. Slots are available through the `slots`
-                key in the Jinja context and accessed as `{{ slots.<name> }}`.
+            make_context: Optional callable that receives the `htmy` rendering context and
+                returns additional Jinja context entries. It runs after `_build_context()`,
+                but before slot rendering, so it can not override the reserved `slots` key.
+            slots: Optional named slots to be rendered in the template. Values are `htmy` components,
+                they are rendered before being passed to Jinja as `markupsafe.Markup` to avoid
+                double-escaping, content is not re-escaped by Jinja's autoescape. Slots are available
+                through the `slots` key in the Jinja context and accessed as `{{ slots.<name> }}`.
         """
         self._template_name = template_name
         self._jinja_context = jinja_context
+        self._make_context = make_context
         self._slots = slots
 
     def _build_context(self, htmy_context: Context, /) -> dict[str, Any]:
@@ -131,8 +142,11 @@ class JinjaTemplate:
         default_slots = DefaultSlots.from_context(context, None)
 
         template = templates.get_template(self._template_name)
-        jinja_context = self._build_context(context)
         slots: dict[str, Markup] = {}
+
+        jinja_context = self._build_context(context)
+        if self._make_context is not None:
+            jinja_context.update(self._make_context(context))
 
         if default_slots is not None:
             for name, component in default_slots.slots.items():

--- a/htmy/jinja.py
+++ b/htmy/jinja.py
@@ -156,8 +156,7 @@ class JinjaTemplate:
             for name, component in self._slots.items():
                 slots[name] = Markup(await renderer.render(component, context))  # noqa: S704
 
-        if len(slots) > 0:
-            jinja_context["slots"] = slots
+        jinja_context["slots"] = slots
 
         if template.environment.is_async:
             rendered = await template.render_async(**jinja_context)

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import pytest
 from jinja2 import Environment, FileSystemLoader
@@ -28,12 +29,13 @@ _ASYNC_TEMPLATES = JinjaTemplates(
     ids=["sync", "async"],
 )
 @pytest.mark.parametrize(
-    ("jinja_context", "slots", "default_slots", "expected"),
+    ("jinja_context", "slots", "default_slots", "make_context", "expected"),
     [
-        pytest.param(None, None, None, "title=\nheading=\nmessage=", id="default-context"),
-        pytest.param({}, None, None, "title=\nheading=\nmessage=", id="empty-context"),
+        pytest.param(None, None, None, None, "title=\nheading=\nmessage=", id="default-context"),
+        pytest.param({}, None, None, None, "title=\nheading=\nmessage=", id="empty-context"),
         pytest.param(
             {"title": "Hello", "heading": "Hi there", "message": "Welcome."},
+            None,
             None,
             None,
             "title=Hello\nheading=Hi there\nmessage=Welcome.",
@@ -43,12 +45,14 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             {"title": "A & B", "heading": "", "message": ""},
             None,
             None,
+            None,
             "title=A &amp; B\nheading=\nmessage=",
             id="autoescape",
         ),
         pytest.param(
             {"title": "Hello"},
             {"children": SafeStr("<b>child</b>")},
+            None,
             None,
             "title=Hello\nheading=\nmessage=\nnav=\nchildren=<b>child</b>",
             id="single-slot",
@@ -57,12 +61,14 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             {"title": "Hello"},
             {"children": SafeStr("body"), "nav": SafeStr("<nav>links</nav>")},
             None,
+            None,
             "title=Hello\nheading=\nmessage=\nnav=<nav>links</nav>\nchildren=body",
             id="multiple-slots",
         ),
         pytest.param(
             {"title": "<b>"},
             {"children": SafeStr("<b>child</b>")},
+            None,
             None,
             "title=&lt;b&gt;\nheading=\nmessage=\nnav=\nchildren=<b>child</b>",
             id="no-double-escape",
@@ -71,13 +77,31 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             {"title": "t", "slots": {"children": "should-not-win"}},
             {"children": SafeStr("real")},
             None,
+            None,
             "title=t\nheading=\nmessage=\nnav=\nchildren=real",
             id="slots-key-is-reserved",
+        ),
+        pytest.param(
+            {"title": "static"},
+            None,
+            None,
+            lambda ctx: {"title": "from make_context"},
+            "title=from make_context\nheading=\nmessage=",
+            id="make-context-overrides-static",
+        ),
+        pytest.param(
+            {"title": "t"},
+            {"children": SafeStr("real")},
+            None,
+            lambda ctx: {"slots": "forbidden"},
+            "title=t\nheading=\nmessage=\nnav=\nchildren=real",
+            id="make-context-cannot-override-slots",
         ),
         pytest.param(
             {"title": "Hello"},
             None,
             {"children": SafeStr("<b>default-child</b>"), "nav": SafeStr("default-nav")},
+            None,
             "title=Hello\nheading=\nmessage=\nnav=default-nav\nchildren=<b>default-child</b>",
             id="default-slots-only",
         ),
@@ -85,6 +109,7 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             {"title": "Hello"},
             {"children": SafeStr("explicit-children")},
             {"children": SafeStr("default-children"), "nav": SafeStr("<nav>default-nav</nav>")},
+            None,
             ("title=Hello\nheading=\nmessage=\nnav=<nav>default-nav</nav>\nchildren=explicit-children"),
             id="default-slots-merged-with-explicit",
         ),
@@ -97,6 +122,7 @@ _ASYNC_TEMPLATES = JinjaTemplates(
                     slots={"children": SafeStr("<i>deep</i>")},
                 )
             },
+            None,
             None,
             (
                 "title=outer-title\nheading=\nmessage=\nnav=\n"
@@ -114,10 +140,16 @@ async def test_jinja_template(
     jinja_context: Mapping[str, object] | None,
     slots: Mapping[str, Component] | None,
     default_slots: Mapping[str, Component] | None,
+    make_context: Any,
     expected: str,
 ) -> None:
     """Renders a Jinja template with both renderers and both template sources."""
-    template = JinjaTemplate("hello-world.jinja", jinja_context=jinja_context, slots=slots)
+    template = JinjaTemplate(
+        "hello-world.jinja",
+        jinja_context=jinja_context,
+        slots=slots,
+        make_context=make_context,
+    )
     component = DefaultSlots(default_slots).in_context(template) if default_slots is not None else template
     for renderer in (default_renderer, baseline_renderer):
         result = await renderer.render(component, context=templates.to_context())

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -1,12 +1,11 @@
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
 
 import pytest
 from jinja2 import Environment, FileSystemLoader
 
 from htmy import Renderer, SafeStr
-from htmy.jinja import DefaultSlots, JinjaTemplate, JinjaTemplates
+from htmy.jinja import DefaultSlots, JinjaContextFactory, JinjaTemplate, JinjaTemplates
 from htmy.renderer import BaselineRenderer
 from htmy.typing import Component
 
@@ -140,7 +139,7 @@ async def test_jinja_template(
     jinja_context: Mapping[str, object] | None,
     slots: Mapping[str, Component] | None,
     default_slots: Mapping[str, Component] | None,
-    make_context: Any,
+    make_context: JinjaContextFactory | None,
     expected: str,
 ) -> None:
     """Renders a Jinja template with both renderers and both template sources."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jinja templates now accept an optional `make_context` hook to compute extra context dynamically at render time.
  * The dynamically generated mapping is merged with existing static context, with slot content retaining priority.
* **Bug Fixes**
  * Slot context handling is now consistent (the `slots` entry is set even when no slots are provided).
  * Dynamic context can override non-slot fields (e.g., `title`) without affecting slot values.
* **Tests**
  * Expanded Jinja template coverage to validate `make_context` behavior and precedence rules.
* **Chores**
  * Bumped package version to `0.12.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->