### PR TITLE
Make jinja default slot rendering opt-in and customizable

### DIFF
--- a/htmy/__init__.py
+++ b/htmy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.1"
+__version__ = "0.13.0"
 
 from .core import ContextAware as ContextAware
 from .core import Formatter as Formatter

--- a/htmy/jinja.py
+++ b/htmy/jinja.py
@@ -129,7 +129,7 @@ class JinjaTemplate:
         self._template_name = template_name
         self._jinja_context = jinja_context
         self._make_context = make_context
-        self._slots = slots
+        self._slots: Mapping[str, Component] = {} if slots is None else slots
         self._use_default_slots = use_default_slots
 
     def _build_context(self, htmy_context: Context, /) -> dict[str, Any]:
@@ -172,11 +172,13 @@ class JinjaTemplate:
 
         if self._use_default_slots:
             for name, component in self._get_default_slots(context).items():
+                if name in self._slots:
+                    continue  # Do not waste time rendering a slot that would be overwritten
+
                 slots[name] = Markup(await renderer.render(component, context))  # noqa: S704
 
-        if self._slots is not None:
-            for name, component in self._slots.items():
-                slots[name] = Markup(await renderer.render(component, context))  # noqa: S704
+        for name, component in self._slots.items():
+            slots[name] = Markup(await renderer.render(component, context))  # noqa: S704
 
         jinja_context["slots"] = slots
 

--- a/htmy/jinja.py
+++ b/htmy/jinja.py
@@ -87,15 +87,17 @@ class JinjaTemplate:
     The template source (a `JinjaTemplates` instance) must be in the `htmy` rendering context.
     The looked up template source is used to load and render the template.
 
-    If a `DefaultSlots` instance is found in the `htmy` rendering context, its slots are rendered
-    and included in the `slots` context variable passed to Jinja. `slots` passed directly to this
-    component take precedence over `DefaultSlots` slots when both contain a slot with the same name.
+    If default slots rendering is enabled (see `use_default_slots`) and `DefaultSlots` is found
+    in the `htmy` rendering context, its slots are rendered and included in the `slots` context
+    variable passed to Jinja. You can customize or filter default slots by overriding
+    `_get_default_slots()`. `slots` passed directly to this component take precedence over
+    `DefaultSlots` slots when both contain a slot with the same name.
 
     Jinja context creation precedence: `jinja_context`, `_build_context()`, `make_context`, and
     finally the reserved `slots` key.
     """
 
-    __slots__ = ("_jinja_context", "_make_context", "_slots", "_template_name")
+    __slots__ = ("_jinja_context", "_make_context", "_slots", "_template_name", "_use_default_slots")
 
     def __init__(
         self,
@@ -104,6 +106,7 @@ class JinjaTemplate:
         jinja_context: Mapping[str, Any] | None = None,
         make_context: JinjaContextFactory | None = None,
         slots: Mapping[str, Component] | None = None,
+        use_default_slots: bool = False,
     ) -> None:
         """
         Initialization.
@@ -118,11 +121,16 @@ class JinjaTemplate:
                 they are rendered before being passed to Jinja as `markupsafe.Markup` to avoid
                 double-escaping, content is not re-escaped by Jinja's autoescape. Slots are available
                 through the `slots` key in the Jinja context and accessed as `{{ slots.<name> }}`.
+            use_default_slots: Whether to render `DefaultSlots` from the `htmy` rendering context.
+                Defaults to `False`, so default slots are only rendered when explicitly requested.
+                Slots passed directly to this component take precedence over default slots with the
+                same name. For finer control over default slots, override `_get_default_slots()`.
         """
         self._template_name = template_name
         self._jinja_context = jinja_context
         self._make_context = make_context
         self._slots = slots
+        self._use_default_slots = use_default_slots
 
     def _build_context(self, htmy_context: Context, /) -> dict[str, Any]:
         """
@@ -135,11 +143,25 @@ class JinjaTemplate:
         """
         return {} if self._jinja_context is None else dict(self._jinja_context)
 
+    def _get_default_slots(self, context: Context, /) -> Mapping[str, Component]:
+        """
+        Returns the default slots to render for this component.
+
+        Override this method to narrow, extend, or suppress default slot rendering without
+        relying solely on the `use_default_slots` flag. The default implementation looks up
+        `DefaultSlots` from the `htmy` rendering context and returns all its slots if it
+        exists, otherwise an empty mapping.
+
+        Arguments:
+            context: The `htmy` rendering context.
+        """
+        default_slots = DefaultSlots.from_context(context, None)
+        return {} if default_slots is None else default_slots.slots
+
     async def htmy(self, context: Context) -> Component:
         """Renders the component."""
         templates = JinjaTemplates.from_context(context)
         renderer = RendererContext.from_context(context)
-        default_slots = DefaultSlots.from_context(context, None)
 
         template = templates.get_template(self._template_name)
         slots: dict[str, Markup] = {}
@@ -148,8 +170,8 @@ class JinjaTemplate:
         if self._make_context is not None:
             jinja_context.update(self._make_context(context))
 
-        if default_slots is not None:
-            for name, component in default_slots.slots.items():
+        if self._use_default_slots:
+            for name, component in self._get_default_slots(context).items():
                 slots[name] = Markup(await renderer.render(component, context))  # noqa: S704
 
         if self._slots is not None:

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -28,15 +28,16 @@ _ASYNC_TEMPLATES = JinjaTemplates(
     ids=["sync", "async"],
 )
 @pytest.mark.parametrize(
-    ("jinja_context", "slots", "default_slots", "make_context", "expected"),
+    ("jinja_context", "slots", "default_slots", "make_context", "use_default_slots", "expected"),
     [
-        pytest.param(None, None, None, None, "title=\nheading=\nmessage=", id="default-context"),
-        pytest.param({}, None, None, None, "title=\nheading=\nmessage=", id="empty-context"),
+        pytest.param(None, None, None, None, False, "title=\nheading=\nmessage=", id="default-context"),
+        pytest.param({}, None, None, None, False, "title=\nheading=\nmessage=", id="empty-context"),
         pytest.param(
             {"title": "Hello", "heading": "Hi there", "message": "Welcome."},
             None,
             None,
             None,
+            False,
             "title=Hello\nheading=Hi there\nmessage=Welcome.",
             id="filled-context",
         ),
@@ -45,6 +46,7 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             None,
             None,
             None,
+            False,
             "title=A &amp; B\nheading=\nmessage=",
             id="autoescape",
         ),
@@ -53,6 +55,7 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             {"children": SafeStr("<b>child</b>")},
             None,
             None,
+            False,
             "title=Hello\nheading=\nmessage=\nnav=\nchildren=<b>child</b>",
             id="single-slot",
         ),
@@ -61,6 +64,7 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             {"children": SafeStr("body"), "nav": SafeStr("<nav>links</nav>")},
             None,
             None,
+            False,
             "title=Hello\nheading=\nmessage=\nnav=<nav>links</nav>\nchildren=body",
             id="multiple-slots",
         ),
@@ -69,6 +73,7 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             {"children": SafeStr("<b>child</b>")},
             None,
             None,
+            False,
             "title=&lt;b&gt;\nheading=\nmessage=\nnav=\nchildren=<b>child</b>",
             id="no-double-escape",
         ),
@@ -77,6 +82,7 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             {"children": SafeStr("real")},
             None,
             None,
+            False,
             "title=t\nheading=\nmessage=\nnav=\nchildren=real",
             id="slots-key-is-reserved",
         ),
@@ -85,6 +91,7 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             None,
             None,
             lambda ctx: {"title": "from make_context"},
+            False,
             "title=from make_context\nheading=\nmessage=",
             id="make-context-overrides-static",
         ),
@@ -93,6 +100,7 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             {"children": SafeStr("real")},
             None,
             lambda ctx: {"slots": "forbidden"},
+            False,
             "title=t\nheading=\nmessage=\nnav=\nchildren=real",
             id="make-context-cannot-override-slots",
         ),
@@ -101,16 +109,36 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             None,
             {"children": SafeStr("<b>default-child</b>"), "nav": SafeStr("default-nav")},
             None,
+            True,
             "title=Hello\nheading=\nmessage=\nnav=default-nav\nchildren=<b>default-child</b>",
             id="default-slots-only",
+        ),
+        pytest.param(
+            {"title": "Hello"},
+            None,
+            {"children": SafeStr("<b>default-child</b>"), "nav": SafeStr("default-nav")},
+            None,
+            False,
+            "title=Hello\nheading=\nmessage=",
+            id="default-slots-opted-out",
         ),
         pytest.param(
             {"title": "Hello"},
             {"children": SafeStr("explicit-children")},
             {"children": SafeStr("default-children"), "nav": SafeStr("<nav>default-nav</nav>")},
             None,
+            True,
             ("title=Hello\nheading=\nmessage=\nnav=<nav>default-nav</nav>\nchildren=explicit-children"),
             id="default-slots-merged-with-explicit",
+        ),
+        pytest.param(
+            {"title": "Hello"},
+            {"children": SafeStr("explicit-children")},
+            {"children": SafeStr("default-children"), "nav": SafeStr("<nav>default-nav</nav>")},
+            None,
+            False,
+            ("title=Hello\nheading=\nmessage=\nnav=\nchildren=explicit-children"),
+            id="default-slots-opted-out-keeps-explicit",
         ),
         pytest.param(
             {"title": "outer-title"},
@@ -123,6 +151,7 @@ _ASYNC_TEMPLATES = JinjaTemplates(
             },
             None,
             None,
+            False,
             (
                 "title=outer-title\nheading=\nmessage=\nnav=\n"
                 "children=title=inner-title\nheading=\nmessage=\nnav=\nchildren=<i>deep</i>"
@@ -140,6 +169,7 @@ async def test_jinja_template(
     slots: Mapping[str, Component] | None,
     default_slots: Mapping[str, Component] | None,
     make_context: JinjaContextFactory | None,
+    use_default_slots: bool,
     expected: str,
 ) -> None:
     """Renders a Jinja template with both renderers and both template sources."""
@@ -148,6 +178,7 @@ async def test_jinja_template(
         jinja_context=jinja_context,
         slots=slots,
         make_context=make_context,
+        use_default_slots=use_default_slots,
     )
     component = DefaultSlots(default_slots).in_context(template) if default_slots is not None else template
     for renderer in (default_renderer, baseline_renderer):


### PR DESCRIPTION
Closes #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `use_default_slots` option to control whether default slots are rendered in Jinja templates.
  * Default slot selection is now overridable/customizable, while explicitly provided slots still take precedence.
* **Tests**
  * Expanded the Jinja template rendering test matrix to validate behavior with default slots both enabled and disabled, including recursive templates.
* **Chores**
  * Bumped the package version to **0.13.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->